### PR TITLE
minor edits for typos and such

### DIFF
--- a/content/couchbase-manual-2.2/administration-basics.markdown
+++ b/content/couchbase-manual-2.2/administration-basics.markdown
@@ -113,7 +113,7 @@ On Linux, Couchbase Server is installed as a standalone application with support
 for running as a background (daemon) process during startup through the use of a
 standard control script, `/etc/init.d/couchbase-server`. The startup script is
 automatically installed during installation from one of the Linux packaged
-releases (Debian/Ubuntu or RedHat/CentOS). By default Couchbase Server is
+releases (Debian/Ubuntu or Red Hat/CentOS). By default Couchbase Server is
 configured to be started automatically at run levels 2, 3, 4, and 5, and
 explicitly shutdown at run levels 0, 1 and 6.
 
@@ -187,7 +187,7 @@ To stop the server using the supplied script:
 
 On Mac OS X, Couchbase Server is supplied as a standard application. You can
 start Couchbase Server by double clicking on the application. Couchbase Server
-runs as a background application which installs a menubar item through which you
+runs as a background application which installs a menu bar item through which you
 can control the server.
 
 
@@ -252,7 +252,7 @@ The individual menu options perform the following actions:
  * `Quit Couchbase`
 
    Selecting this menu option will shut down your running Couchbase Server, and
-   close the menubar interface. To restart, you must open the Couchbase Server
+   close the menu bar interface. To restart, you must open the Couchbase Server
    application from the installation folder.
 
 <a id="couchbase-bestpractice"></a>

--- a/content/couchbase-manual-2.2/administration-tasks.markdown
+++ b/content/couchbase-manual-2.2/administration-tasks.markdown
@@ -1236,7 +1236,7 @@ failover is not without potential problems.
 
  * **External monitoring**
 
-   [Another option is to have a system monitoring the cluster via theManagement
+   [Another option is to have a system monitoring the cluster via the Management
    REST API](#couchbase-admin-restapi). Such an external system is in a good
    position to failover nodes because it can take into account system components
    that are outside the scope of Couchbase Server.
@@ -1697,7 +1697,7 @@ There are a number of methods for performing a backup:
    For more information, see [Backing Up Using File
    Copies](#couchbase-backup-restore-backup-filecopy).
 
-   [To restore, you need to use thefile copy](#couchbase-backup-restore-filecopy)
+   [To restore, you need to use the file copy](#couchbase-backup-restore-filecopy)
    method.
 
 Due to the active nature of Couchbase Server it is impossible to create a
@@ -2722,7 +2722,7 @@ be updated or upgraded.
 
 Before you remove a node from the cluster, you should ensure that you have the
 capacity within the remaining nodes of your cluster to handle your workload. For
-more information on the considerations, seeChoosing when to shrink your cluster.
+more information on the considerations, see Choosing when to shrink your cluster.
 For the best results, use swap rebalance to swap the node you want to remove
 out, and swap in a replacement node. For more information on swap rebalance, see
 [Swap Rebalance](#couchbase-admin-tasks-addremove-rebalance-swap).
@@ -2901,7 +2901,7 @@ The benefits of swap rebalance are:
    the capacity of the cluster remains unchanged during the rebalance operation,
    helping to ensure performance and failover support.
 
-The behaviour of the cluster during a failover and rebalance operation with the
+The behavior of the cluster during a failover and rebalance operation with the
 swap rebalance functionality affects the following situations:
 
  * **Stopping a rebalance**
@@ -3531,7 +3531,7 @@ If you change want the replication protocol for an existing XDCR replication, yo
 
     - `XDCR Batch Size (KB)`
 
-      Document batching size, 10 to 100000 (kB). Default 2048. In general, increasing
+      Document batching size, 10 to 100000 (KB). Default 2048. In general, increasing
       this value by 2 or 3 times will improve XDCR transmissions rates, since larger
       batches of data will be sent in the same timed interval. For unidirectional
       replication from a source to a destination cluster, adjusting this setting by 2
@@ -3713,7 +3713,7 @@ active will be displayed within the `Past Replications` section of the
 ### Upgrading with XDCR
 
 As of Couchbase Server 2.2 we introduce a second replication mode known as `xmem` which performs
- replication on a destination cluster with the memcached prototocol. This is the default mode for 
+ replication on a destination cluster with the memcached protocol. This is the default mode for 
  replications for Couchbase Server 2.2+. The other mode which exists is known as `capi` and is over 
  a REST protocol. When you upgrade Couchbase Server you need to make sure that both 
  your source and destination clusters support the replication mode you want to use. You may also need to delete the replication, complete the upgrade, then recreate the replication. If you do not, you could experience data loss during replication:
@@ -4044,7 +4044,7 @@ To change the disk path of the existing node, the recommended sequence is:
 
  1. Configure the new disk path, either by using the REST API (see [Configuring
     Index Path for a Node](#couchbase-admin-restapi-provisioning-diskpath) ), using
-    the command-line (seecluster initializationfor more information).
+    the command-line (see cluster initialization for more information).
 
     Alternatively, connect to the Web UI of the new node, and follow the setup
     process to configure the disk path (see [Initial Server

--- a/content/couchbase-manual-2.2/appendix-couchbase-sample-buckets.markdown
+++ b/content/couchbase-manual-2.2/appendix-couchbase-sample-buckets.markdown
@@ -236,7 +236,7 @@ The primary document type is the 'beer' document:
 ```
 
 Beer documents contain core information about different beers, including the
-name, alcohol by volume ( `abv` ) and categorisation data.
+name, alcohol by volume ( `abv` ) and categorization data.
 
 Individual beer documents are related to brewery documents using the
 `brewery_id` field, which holds the information about a specific brewery for the
@@ -265,8 +265,8 @@ beer:
 }
 ```
 
-The brewery reconrd includes basic contact and address information for the
-brewery, and contains a spatial record consisting of the latitute and longitude
+The brewery record includes basic contact and address information for the
+brewery, and contains a spatial record consisting of the latitude and longitude
 of the brewery location.
 
 To demonstrate the view functionality in Couchbase Server, three views are

--- a/content/couchbase-manual-2.2/appendix-faqs.markdown
+++ b/content/couchbase-manual-2.2/appendix-faqs.markdown
@@ -23,7 +23,7 @@
    stream of all items stored in the server, even if no other clients are making
    any item changes. On the TAP stream connection setup options, a TAP stream
    client may request to receive just current items stored in the server (all items
-   until "now"), or all item changes from now onwards into in the future, or both.
+   until "now"), or all item changes from now onward into in the future, or both.
 
    Trond Norbye's written a blog post about the TAP interface. See [Blog
    Entry](http://blog.couchbase.com/want-know-what-your-memcached-servers-are-doing-tap-them).

--- a/content/couchbase-manual-2.2/appendix-release-notes.markdown
+++ b/content/couchbase-manual-2.2/appendix-release-notes.markdown
@@ -49,7 +49,7 @@ Additional enhancements in 2.2 include:
       `xdcr_optimistic_replication_threshold`, `xdcr_worker_batch_size`,
       `xdcr_connection_timeout`, `xdcr_num_worker_process`,
       `xdcr_num_http_connections`, and `xdcr_num_retries_per_request`. You can now
-      change these settings and they will immeidately apply to the existing XDCR
+      change these settings and they will immediately apply to the existing XDCR
       replication. For more information, see [Changing Internal XDCR
       Settings](#couchbase-admin-restapi-xdcr-change-settings).
 

--- a/content/couchbase-manual-2.2/appendix-troubleshooting-views-technical-background-.markdown
+++ b/content/couchbase-manual-2.2/appendix-troubleshooting-views-technical-background-.markdown
@@ -539,7 +539,7 @@ The documents included in each row don't match the value field of each row, that
 is, the documents included are the latest (updated) versions but the index row
 values still reflect the previous (first) version of the documents.
 
-Why this behaviour? Well, `include_docs=true` works by at query time, for each
+Why this behavior? Well, `include_docs=true` works by at query time, for each
 row, to fetch from disk the latest revision of each document. There's no way to
 include a previous revision of a document. Previous revisions are not accessible
 through the latest vbucket databases MVCC snapshots (
@@ -553,7 +553,7 @@ The only way to ensure full consistency here is to include the documents
 themselves in the values emitted by the map function. Queries with `stale=false`
 are not 100% reliable either, as just after the index is updated and while rows
 are being streamed from disk to the client, document updates and deletes can
-still happen, resulting in the same behaviour as in the given example.
+still happen, resulting in the same behavior as in the given example.
 
 <a id="couchbase-views-debugging-expired"></a>
 
@@ -882,7 +882,7 @@ as `couch_dbinfo` and `couch_dbdump` to analyze active vbucket database files.
 Before looking at those tools, lets first know what database sequence numbers
 are.
 
-When a couchdb database (remember, each corresponds to a vbucket) is created,
+When a CouchDB database (remember, each corresponds to a vbucket) is created,
 its update\_seq (update sequence number) is 0. When a document is created,
 updated or deleted, its current sequence number is incremented by 1. So all the
 following sequence of actions result in the final sequence number of 5:
@@ -2104,7 +2104,7 @@ the following information to JIRA issues:
  * If you generated the data with any tool, mention its name and all the parameters
    given to it (full command line)
 
- * Show what queries you were doing (include all query parameters, full url), use
+ * Show what queries you were doing (include all query parameters, full URL), use
    curl with option -v and show the full output, example:
 
 

--- a/content/couchbase-manual-2.2/appendix-uninstalling-couchbase-server.markdown
+++ b/content/couchbase-manual-2.2/appendix-uninstalling-couchbase-server.markdown
@@ -18,16 +18,16 @@ Before removing Couchbase Server from your system, you should do the following:
 
 <a id="couchbase-uninstalling-redhat"></a>
 
-## Uninstalling on a RedHat Linux System
+## Uninstalling on a Red Hat Linux System
 
-To uninstall the software on a RedHat Linux system, run the following command:
+To uninstall the software on a Red Hat Linux system, run the following command:
 
 
 ```
 > sudo rpm -e couchbase-server
 ```
 
-Refer to the RedHat RPM documentation for more information about uninstalling
+Refer to the Red Hat RPM documentation for more information about uninstalling
 packages using RPM.
 
 You may need to delete the data files associated with your installation. The

--- a/content/couchbase-manual-2.2/best-practices.markdown
+++ b/content/couchbase-manual-2.2/best-practices.markdown
@@ -149,7 +149,7 @@ Constant                                                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Metadata per document (metadata\_per\_document)                                                                                                                                                  | This is the amount of memory that Couchbase needs to store metadata per document. Prior to Couchbase 2.1, metadata used 64 bytes. As of Couchbase 2.1, metadata uses 56 bytes. All the metadata needs to live in memory while a node is running and serving data.
 SSD or Spinning                                                                                                                                                                                  | SSDs give better I/O performance.                                                                                                                                                                                                                                
-headroomThe cluster needs additonal overhead to store metadata. That space is called the headroom. This requires approximately 25-30% more space than the raw RAM requirements for your dataset. | Since SSDs are faster than spinning (traditional) hard disks, you should set aside 25% of memory for SSDs and 30% of memory for spinning hard disks.                                                                                                             
+headroom The cluster needs additional overhead to store metadata. That space is called the headroom. This requires approximately 25-30% more space than the raw RAM requirements for your dataset. | Since SSDs are faster than spinning (traditional) hard disks, you should set aside 25% of memory for SSDs and 30% of memory for spinning hard disks.                                                                                                             
 High Water Mark (high\_water\_mark)                                                                                                                                                              | By default, the high water mark for a node's RAM is set at 70%.                                                                                                                                                                                                  
 
 This is a rough guideline to size your cluster:
@@ -360,7 +360,7 @@ primary concerns for your servers, here is what we recommend:
       throughput.
 
  * Network: Most configurations will work with Gigabit Ethernet interfaces. Faster
-   solutions such as 10GBit and Inifiniband will provide spare capacity.
+   solutions such as 10GBit and Infiniband will provide spare capacity.
 
 <a id="couchbase-bestpractice-sizing-cloud"></a>
 
@@ -449,7 +449,7 @@ following:
 [The water mark is another key statistic to monitor cluster performance. The
 'water mark' determines when it is necessary to start freeing up available
 memory. Read more about this
-concepthere](#couchbase-introduction-architecture-diskstorage). Here are two
+concept here](#couchbase-introduction-architecture-diskstorage). Here are two
 important statistics related to water marks:
 
  * High Water Mark ( `ep_mem_high_wat` )
@@ -713,7 +713,7 @@ are moved to the swap space. From a range of 0 to 100, swappiness indicates how
 frequently a system should use swap space based on RAM usage. We recommend the
 following for swap space:
 
- * By default on most Linux platforms, swapiness is set to 60. However this will
+ * By default on most Linux platforms, swappiness is set to 60. However this will
    make a system go into swap too frequently for Couchbase Server.
 
  * If you use Couchbase Server 2.0+ without views, we recommend setting swappiness
@@ -806,7 +806,7 @@ communicate with Couchbase Cluster without installing another piece of proxy
 software. The downside to this approach is performance.
 
 In this deployment option versus a typical memcached deployment, in a worse-case
-scenario, server mapping will happen twice (e.g. using ketama hashing to a
+scenario, server mapping will happen twice (e.g. using Ketama hashing to a
 server list on the client, then using vBucket hashing and server mapping on the
 proxy) with an additional round trip network hop introduced.
 

--- a/content/couchbase-manual-2.2/command-line-interface-for-administration.markdown
+++ b/content/couchbase-manual-2.2/command-line-interface-for-administration.markdown
@@ -531,7 +531,7 @@ node. If you want to perform this operation for an entire cluster, you will need
 to perform the command for every node/bucket combination that exists for that
 cluster.
 
-[You use this tool to get thecouchbase node
+[You use this tool to get the couchbase node
 statistics](#couchbase-monitoring-nodestats). The general format for the command
 is:
 
@@ -680,7 +680,7 @@ The following provides the stats that are created by `cbstats`:
 | ep_num_expiry_pager_runs           | Number of times we ran expiry pager    
 |                                    | loops to purge expired items from      
 |                                    | memory/disk                            
-| ep_num_access_scanner_runs         | Number of times we ran accesss scanner 
+| ep_num_access_scanner_runs         | Number of times we ran access scanner 
 |                                    | to snapshot working set                
 | ep_access_scanner_num_items        | Number of items that last access       
 |                                    | scanner task swept to access log.      
@@ -710,7 +710,7 @@ The following provides the stats that are created by `cbstats`:
 | ep_pending_ops_max_duration        | Max time (µs) used waiting on pending  
 |                                    | vbuckets                               
 | ep_bg_num_samples                  | The number of samples included in the  
-|                                    | avgerage                               
+|                                    | average                               
 | ep_bg_min_wait                     | The shortest time (µs) in the wait     
 |                                    | queue                                  
 | ep_bg_max_wait                     | The longest time (µs) in the wait      
@@ -751,14 +751,14 @@ The following provides the stats that are created by `cbstats`:
 | ep_config_file                     | The location of the ep-engine config   
 |                                    | file                                   
 | ep_couch_bucket                    | The name of this bucket                
-| ep_couch_host                      | The hostname that the couchdb views    
+| ep_couch_host                      | The hostname that the CouchDB views    
 |                                    | server is listening on                 
-| ep_couch_port                      | The port the couchdb views server is   
+| ep_couch_port                      | The port the CouchDB views server is   
 |                                    | listening on                           
 | ep_couch_reconnect_sleeptime       | The amount of time to wait before      
-|                                    | reconnecting to couchdb                
+|                                    | reconnecting to CouchDB                
 | ep_couch_response_timeout          | Length of time to wait for a response  
-|                                    | from couchdb before reconnecting       
+|                                    | from CouchDB before reconnecting       
 | ep_data_traffic_enabled            | Whether or not data traffic is enabled 
 |                                    | for this bucket                        
 | ep_degraded_mode                   | True if the engine is either warming   
@@ -843,7 +843,7 @@ The following provides the stats that are created by `cbstats`:
 |                                    | before we enable traffic               
 | ep_warmup_min_memory_threshold     | Percentage of max mem warmed up before 
 |                                    | we enable traffic                      
-| ep_warmup_oom                      | The amount of oom errors that occured  
+| ep_warmup_oom                      | The amount of oom errors that occurred  
 |                                    | during warmup                          
 | ep_warmup_thread                   | The status of the warmup thread        
 | ep_warmup_time                     | The amount of time warmup took
@@ -1186,7 +1186,7 @@ and performance will suffer.
 | largest_min  | The the largest minimum hash table depth of all vbuckets 
 | max_count    | The largest number of items in a vbucket                 
 | min_count    | The smallest number of items in a vbucket                
-| total_counts | The total numer of items in all vbuckets
+| total_counts | The total number of items in all vbuckets
 
 It is also possible to get more detailed hash tables stats by using
 'hash detail'. This will print per-vbucket stats.
@@ -1213,7 +1213,7 @@ vbucket 0 is =vb_0:size=.
 ###Checkpoint Stats
 
 Checkpoint stats provide detailed information on per-vbucket checkpoint
-datastructure.
+data structure.
 
 Like Hash stats, requesting these stats has some impact on performance.
 Therefore, please do not poll them from the server frequently.
@@ -1227,17 +1227,17 @@ each stat name.
 | open_checkpoint_id               | ID of the current open checkpoint         
 | num_tap_cursors                  | Number of referencing TAP cursors         
 | num_checkpoint_items             | Number of total items in a checkpoint     
-|                                  | datastructure                             
+|                                  | data structure                             
 | num_open_checkpoint_items        | Number of items in the open checkpoint    
 | num_checkpoints                  | Number of checkpoints in a checkpoint     
-|                                  | datastructure                             
+|                                  | data structure                             
 | num_items_for_persistence        | Number of items remaining for persistence 
 | checkpoint_extension             | True if the open checkpoint is in the     
 |                                  | extension mode                            
 | state                            | The state of the vbucket this checkpoint  
 |                                  | contains data for                         
 | last_closed_checkpoint_id        | The last closed checkpoint number         
-| persisted_checkpoint_id          | The slast persisted checkpoint number
+| persisted_checkpoint_id          | The last persisted checkpoint number
 
 ###Memory Stats
 
@@ -1304,7 +1304,7 @@ Note that tcmalloc stats are not available on some operating systems
 
 - length_mismatch - The key length in memory doesn't match the length on disk.
 
-- data_mismatch - The data in memroy doesn't match the data on disk.
+- data_mismatch - The data in memory doesn't match the data on disk.
 
 - flags_mismatch - The flags in memory don't match the flags on disk.
 
@@ -2048,7 +2048,7 @@ Parameter                       | Description
 **alog\_sleep\_time**           | Access scanner interval (minute)                                                                                                   
 **alog\_task\_time**            | Access scanner next task time (UTC)                                                                                                
 **bg\_fetch\_delay**            | Delay before executing a bg fetch (test feature).                                                                                  
-**couch\_response\_timeout**    | timeout in receiving a response from couchdb.                                                                                      
+**couch\_response\_timeout**    | timeout in receiving a response from CouchDB.                                                                                      
 **exp\_pager\_stime**           | Expiry Pager interval. Time interval that Couchbase Server waits before it performs cleanup and removal of expired items from disk.
 **flushall\_enabled**           | Enable flush operation.                                                                                                            
 **klog\_compactor\_queue\_cap** | queue cap to throttle the log compactor.                                                                                           
@@ -2450,7 +2450,7 @@ Where:
 
  * `[destination]`
 
-   The destination bucket for the restored information. This is a bucker in an
+   The destination bucket for the restored information. This is a bucket in an
    existing cluster. If you restore the data to a single node in a cluster, provide
    the hostname and port for the node you want to restore to. If you restore an
    entire data bucket, provide the URL of one of the nodes within the cluster.
@@ -2522,7 +2522,7 @@ default port of `8091`. The default number of vBuckets for Couchbase 2.0 is
 1024; in earlier versions of Couchbase, you may have a different number of
 vBuckets. If you do want to restore data to a cluster with a different number of
 vBuckets, you should perform this command with port `11211`, which will
-accomodate the difference in vBuckets:
+accommodate the difference in vBuckets:
 
 
 ```
@@ -2789,7 +2789,7 @@ that must be addressed immediately.
 [The tool retrieves data from the Couchbase Server monitoring system, aggregates
 it over a time scale, analyzes the statistics against thresholds, and generates
 a report. Unlike other command line tools such as `cbstats` and `cbtransfer`
-that use theTAP protocol](#couchbase-introduction-architecture-tap) to obtain
+that use the TAP protocol](#couchbase-introduction-architecture-tap) to obtain
 data from the monitoring system, `cbhealthchecker` obtains data by using the
 REST API and the memcached protocol. For more information about the statistics
 provided by Couchbase Server, see [Statistics and

--- a/content/couchbase-manual-2.2/installing-and-upgrading.markdown
+++ b/content/couchbase-manual-2.2/installing-and-upgrading.markdown
@@ -23,7 +23,7 @@ To start using Couchbase Server, you need to follow these steps:
 ## Preparation
 
 Mixed deployments, such as cluster with both Linux and Windows server nodes are
-not supported. This incomparability is due to differences in the number of
+not supported. This incompatibility is due to differences in the number of
 shards between platforms. It is not possible either to mix operating systems
 within the same cluster, or configure XDCR between clusters on different
 platforms. You should use same operating system on all machines within a cluster
@@ -53,11 +53,11 @@ Windows 2008             | R2 with SP1 | 64 bit          | Developer and Product
 Windows 2012             |             | 64 bit          | Developer and Production |  
 Windows 7                |             | 32 and 64 bit   | Developer only           |                        
 Windows 8                |             | 32 and 64 bit   | Developer only           |                        
-MacOS                    | 10.7        | 64 bit          | Developer only           |                        
-MacOS                    | 10.8        | 64 bit          | Developer only           | MacOS 10.8             
+Mac OS                    | 10.7        | 64 bit          | Developer only           |                        
+Mac OS                    | 10.8        | 64 bit          | Developer only           | Mac OS 10.8             
 
 **Couchbase clusters with mixed platforms are not supported.** Specifically,
-Couchbase Server on MacOSX uses 64 vBuckets as opposed to the 1024 vBuckets used
+Couchbase Server on Mac OS X uses 64 vBuckets as opposed to the 1024 vBuckets used
 by other platforms. Due to this difference, if you need to move data between a
 Mac OS X cluster and a cluster hosted on another platform use `cbbackup` and
 `cbrestore`. For more information, see [Backup and Restore Between Mac OS X and
@@ -119,7 +119,7 @@ Guidelines](#couchbase-bestpractice-sizing).
 
 ### Supported Web Browsers
 
-The Couchbase Web Console runs on the following browsers, with Javascript
+The Couchbase Web Console runs on the following browsers, with JavaScript
 support enabled:
 
  * Mozilla Firefox 3.6 or higher
@@ -216,9 +216,9 @@ To perform an upgrade installation while retaining your existing dataset, see
 ### Red Hat Linux Installation
 
 Before you install, make sure you check the supported platforms, see [Supported
-Platforms](#couchbase-getting-started-prepare-platforms). The RedHat
-installation uses the RPM package. Installation is supported on RedHat and
-RedHat-based operating systems such as CentOS.
+Platforms](#couchbase-getting-started-prepare-platforms). The Red Hat
+installation uses the RPM package. Installation is supported on Red Hat and
+Red Hat-based operating systems such as CentOS.
 
  1. For Red Hat Enterprise Linux version 6.0, Couchbase Server 2.2 RPM will do
     dependency checks for OpenSSL using `pkg-config`. Therefore you need to check
@@ -274,7 +274,7 @@ RedHat-based operating systems such as CentOS.
 
     Once the `rpm` command completes, Couchbase Server starts automatically, and is
     configured to automatically start during boot under the 2, 3, 4, and 5
-    runlevels. Refer to the RedHat RPM documentation for more information about
+    runlevels. Refer to the Red Hat RPM documentation for more information about
     installing packages using RPM.
 
     After installation finishes, the installation process will display a message
@@ -282,7 +282,7 @@ RedHat-based operating systems such as CentOS.
 
      ```
      Minimum RAM required  : 4 GB
-     System RAM configured : 8174464 kB
+     System RAM configured : 8174464 KB
 
      Minimum number of processors required : 4 cores
      Number of processors on the system    : 4 cores
@@ -301,9 +301,9 @@ RedHat-based operating systems such as CentOS.
      See /opt/couchbase/LICENSE.txt.
      ```
 
-Once installed, you can use the RedHat `chkconfig` command to manage the
+Once installed, you can use the Red Hat `chkconfig` command to manage the
 Couchbase Server service, including checking the current status and creating the
-links to enable and disable automatic start-up. Refer to the [RedHat
+links to enable and disable automatic start-up. Refer to the [Red Hat
 documentation](https://access.redhat.com/site/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/s2-services-chkconfig.html)
 for instructions.
 
@@ -311,11 +311,11 @@ To do the initial setup for Couchbase, open a web browser and access the
 Couchbase Web Console. See [Initial Server
 Setup](#couchbase-getting-started-setup).
 
-###Installing on Centos/RHEL as Non-Root, Non-Sudo 
+###Installing on CentOS/RHEL as Non-Root, Non-Sudo 
 
 **This installation is for development purposes only.** There may be cases when you want to install the server as a non-root, non-sudo
 user. If you perform a non-sudo, non-root installation you will be still be able to run Couchbase Server and all 
-Couchbase command-line tools. To do so on Centos/RedHat:
+Couchbase command-line tools. To do so on CentOS/Red Hat:
 
  1. After you download the Couchbase RPM, go to the directory where it is located
     and extract it:
@@ -411,7 +411,7 @@ Platforms](#couchbase-getting-started-prepare-platforms).
      Unpacking couchbase-server (from couchbase-server_x86_64_2.1.0-xxx-rel.deb) ...
      libssl0.9.8 is installed. Continue installing
      Minimum RAM required  : 4 GB
-     System RAM configured : 4058708 kB
+     System RAM configured : 4058708 KB
 
      Minimum number of processors required : 4 cores
      Number of processors on the system    : 4 cores
@@ -610,7 +610,7 @@ which contains a standalone application that can be copied to the `Applications`
 folder or to any other location you choose. The installation location is not the
 same as the location of the Couchbase data files.
 
-Please use the default archive file hander in Mac OS X, Archive Utility, when
+Please use the default archive file handler in Mac OS X, Archive Utility, when
 you unpack the Couchbase Server distribution. It is more difficult to diagnose
 non-functioning or damaged installations after extraction by other third party
 archive extraction tools.
@@ -658,9 +658,9 @@ directory. You can access them in Terminal by using the full path of the
 Couchbase Server installation. By default, this is
 `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/`.
 
-###Installing on Mac OSX as Non-Root, Non-Sudo
+###Installing on Mac OS X as Non-Root, Non-Sudo
 
-**This installation is for development purposes only.** There may be cases when you want to install the server as a non-root, non-sudo user. If you perform a non-sudo, non-root installation you will be still be able to run Couchbase Server and all Couchbase command-line tools. To do so on Mac OSX:
+**This installation is for development purposes only.** There may be cases when you want to install the server as a non-root, non-sudo user. If you perform a non-sudo, non-root installation you will be still be able to run Couchbase Server and all Couchbase command-line tools. To do so on Mac OS X:
 
  1. After you download Couchbase Server, open Terminal and go to the Downloads
     directory:
@@ -787,7 +787,7 @@ port other than `8091`, go to that port.
     When you provide an email address we will add it to the Couchbase community
     mailing list for news and update information about Couchbase and related
     products. You can unsubscribe from the mailing list at any time using the
-    unsubscribe link provided in each newletter. Web Console communicates the
+    unsubscribe link provided in each newsletter. Web Console communicates the
     following information:
 
      * The current version. When a new version of Couchbase Server exists, you get
@@ -1384,7 +1384,7 @@ an individual nodes in a cluster remain the same:
 
  1. Perform the installation upgrade for your platform:
 
-    **RHEL/Centos**
+    **RHEL/CentOS**
 
     You can perform an upgrade install using the RPM package — this will keep the
     data and existing configuration.
@@ -1436,7 +1436,7 @@ rebalance may fail.
 When you upgrade from Couchbase Server 1.8 to Couchbase Server 2.1+ on Linux,
 you should be aware of the **OpenSSL** requirement. OpenSSL is a required
 component and you will get an error message during upgrade if it is not
-installed. To install it RedHat-based systems, use `yum` :
+installed. To install it Red Hat-based systems, use `yum` :
 
 
 ```
@@ -1458,10 +1458,10 @@ the IP and hostname configuration is correct both before the upgrade and after
 upgrading the software. See [Hostnames for Couchbase Server 2.0.1 and
 Earlier](#couchbase-getting-started-hostnames-pre2.0).
 
-**Mac OSX Notes for 1.8.1 to 2.1+**
+**Mac OS X Notes for 1.8.1 to 2.1+**
 
-There is currently no officially supported upgrade installer for Mac OSX. If you
-want to migrate to 1.8.1 to 2.1+ on OSX, you must make a backup of your data
+There is currently no officially supported upgrade installer for Mac OS X. If you
+want to migrate to 1.8.1 to 2.1+ on OS X, you must make a backup of your data
 files with `cbbackup`, install the latest version, then restore your data with
 `cbrestore`. For more information, see [cbbackup
 Tool](#couchbase-admin-cmdline-cbbackup) and [cbrestore

--- a/content/couchbase-manual-2.2/introduction-to-couchbase-server.markdown
+++ b/content/couchbase-manual-2.2/introduction-to-couchbase-server.markdown
@@ -290,7 +290,7 @@ Buckets](#couchbase-admin-web-console-data-buckets-createedit).
    caching data *for all buckets* and is configured on a per-node basis. The Server
    Quota is initially configured in the first server in your cluster is configured,
    and the quota is identical on all nodes. For example, if you have 10 nodes and a
-   16GB Server Quota, ther is 160GB RAM available across the cluster. If you were
+   16GB Server Quota, there is 160GB RAM available across the cluster. If you were
    to add two more nodes to the cluster, the new nodes would need 16GB of free RAM,
    and the aggregate RAM available in the cluster would be 192GB.
 
@@ -307,7 +307,7 @@ Buckets](#couchbase-admin-web-console-data-buckets-createedit).
 ![](images/ram-quotas.png)
 
 From this description and diagram, you can see that adding new nodes to the
-cluster expands the overal RAM quota, and the bucket quota, increasing the
+cluster expands the overall RAM quota, and the bucket quota, increasing the
 amount of information that can be kept in RAM.
 
 [The Bucket Quota is used by the system to determine when data should
@@ -336,8 +336,8 @@ data, and for supporting replicas (copies of bucket data) on more than one node.
 Clients access the information stored in a bucket by communicating directly with
 the node response for the corresponding vBucket. This direct access enables
 clients to communicate with the node storing the data, rather than using a proxy
-or redistribution architecture. The result is abstracting the physical toplogy
-from the logical partitioning of data. This architecture is what gives Coucbase
+or redistribution architecture. The result is abstracting the physical topology
+from the logical partitioning of data. This architecture is what gives Couchbase
 Server the elasticity.
 
 This architecture differs from the method used by `memcached`, which uses
@@ -376,7 +376,7 @@ node, Server D is added to the cluster and the vBucket Map is updated.
 ![](images/vbuckets-after.png)
 
 [The vBucket map is updated during
-therebalance](#couchbase-introduction-architecture-rebalancing) operation; the
+the rebalance](#couchbase-introduction-architecture-rebalancing) operation; the
 updated map is then sent the cluster to all the cluster participants, including
 the other nodes, any connected "smart" clients, and the Moxi proxy service.
 
@@ -685,7 +685,7 @@ provides a stream of data of the changes that are occurring within the system.
 
 TAP is used during replication, to copy data between vBuckets used for replicas.
 It is also used during the rebalance procedure to move data between vBuckets and
-redestribute the information across the system.
+redistribute the information across the system.
 
 <a id="couchbase-introduction-architecture-clientinterface"></a>
 
@@ -937,10 +937,10 @@ the basic running of a Membase cluster.
 
    To build Views that can output and query your stored data, your objects must be
    stored in the database using the JSON format. This may mean that if you have
-   been using the native serialisation of your client library to convert a language
+   been using the native serialization of your client library to convert a language
    specific object so that it can be stored into Membase Server, you will now need
    to structure your data and use a native to JSON serialization solution, or
-   reformat your data so that it can be formated as JSON.
+   reformat your data so that it can be formatted as JSON.
 
 <a id="couchbase-introduction-migration-couchdb"></a>
 

--- a/content/couchbase-manual-2.2/monitoring-couchbase.markdown
+++ b/content/couchbase-manual-2.2/monitoring-couchbase.markdown
@@ -147,7 +147,7 @@ the system is understanding how we interact with the disk subsystem.
 
 Since Couchbase Server is an asynchronous system, any mutation operation is
 committed first to DRAM and then queued to be written to disk. The client is
-returned an acknowledgement almost immediately so that it can continue working.
+returned an acknowledgment almost immediately so that it can continue working.
 There is replication involved here too, but we're ignoring it for the purposes
 of this discussion.
 
@@ -183,7 +183,7 @@ gathering node-level stats). There are two statistics to watch here:
 ep\_queue\_size (where new mutations are placed) flusher\_todo (the queue of
 items currently being written to disk)
 
-[SeeThe Dispatcher](#couchbase-monitoring-nodestats-dispatcher) for more
+[See The Dispatcher](#couchbase-monitoring-nodestats-dispatcher) for more
 information about monitoring what the disk subsystem is doing at any given time.
 
 <a id="couchbase-monitoring-stats"></a>
@@ -217,7 +217,7 @@ can be found in the repository.
 
 [Along with stats at the REST and UI level, individual nodes can also be queried
 for statistics either through a client which uses binary protocol or through
-thecbstats utility](#couchbase-admin-cmdline-cbstats) shipped with Couchbase
+the cbstats utility](#couchbase-admin-cmdline-cbstats) shipped with Couchbase
 Server.
 
 For example:

--- a/content/couchbase-manual-2.2/troubleshooting.markdown
+++ b/content/couchbase-manual-2.2/troubleshooting.markdown
@@ -15,7 +15,7 @@ more detailed investigations:
 
  * Try connecting to the Couchbase Server Web Console on the node.
 
- * [Try to use telnet to connect to the variousports](#couchbase-network-ports)
+ * [Try to use telnet to connect to the various ports](#couchbase-network-ports)
    that Couchbase Server uses.
 
  * Try reloading the web page.
@@ -116,14 +116,14 @@ File               | Log Contents
 `info`             | Information level error messages related to the core server management subsystem, excluding information included in the `couchdb`, `xdcr` and `stats` logs.
 `error`            | Error level messages for all subsystems excluding `xdcr`.                                                                                                  
 `xcdr_error`       | XDCR error messages.                                                                                                                                       
-`xdcr`             | XSCR information messages.                                                                                                                                 
+`xdcr`             | XDCR information messages.                                                                                                                                 
 `mapreduce_errors` | JavaScript and other view-processing errors are reported in this file.                                                                                     
 `views`            | Errors relating to the integration between the view system and the core server subsystem.                                                                  
 `stats`            | Contains periodic reports of the core statistics.                                                                                                          
 `memcached.log`    | Contains information relating to the core memcache component, including vBucket and replica and rebalance data streams requests.                           
 
-Each logfile group will also include a `.idx` and `.siz` file which holds meta
-information about the logfile group. These files are automatically updated by
+Each log file group will also include a `.idx` and `.siz` file which holds meta
+information about the log file group. These files are automatically updated by
 the logging system.
 
 <a id="couchbase-troubleshooting-common-errors"></a>

--- a/content/couchbase-manual-2.2/using-the-rest-api.markdown
+++ b/content/couchbase-manual-2.2/using-the-rest-api.markdown
@@ -167,7 +167,7 @@ you would use for a REST API request. This is especially for administrative
 tasks such as creating a new bucket, adding a node to a cluster, or changing
 cluster settings.
 
-[For a list of supported browsers, seeSystem
+[For a list of supported browsers, see System
 Requirements](#couchbase-getting-started-prepare). For the Couchbase Web
 Console, a separate UI hierarchy is served from each node of the system (though
 asking for the root "/" would likely return a redirect to the user agent). To
@@ -368,7 +368,7 @@ Host: 10.4.2.4:8091
 Accept: */*
 ```
 
-If Couchbase Server successfully handles the reuqest, you will get a response
+If Couchbase Server successfully handles the request, you will get a response
 similar to the following example:
 
 
@@ -1468,7 +1468,7 @@ For example, to edit the bucket `customer` :
 ```
 
 [Available parameters are identical to those available when creating a bucket.
-Seebucket parameters](#table-couchbase-admin-restapi-creating-buckets).
+See bucket parameters](#table-couchbase-admin-restapi-creating-buckets).
 
 If the request is successful, HTTP response 200 will be returned with an empty
 data content.
@@ -2566,7 +2566,7 @@ Authorization: Basic YWRtaW46YWRtaW4=
 
 200 OK
 
-Possible errrors include:
+Possible errors include:
 
 
 ```

--- a/content/couchbase-manual-2.2/using-the-web-console.markdown
+++ b/content/couchbase-manual-2.2/using-the-web-console.markdown
@@ -162,7 +162,7 @@ The `Servers` section indicates overall server information for the cluster:
 
 ![](images/web-console-cluster-overview-servers.png)
 
- * `Active Servers` is the number of active servers within the current clsuter
+ * `Active Servers` is the number of active servers within the current cluster
    configuration.
 
  * `Servers Failed Over` is the number of servers that have failed over due to an
@@ -171,7 +171,7 @@ The `Servers` section indicates overall server information for the cluster:
  * `Servers Down` shows the number of servers that are down and not-contactable.
 
  * `Servers Pending Rebalance` shows the number of servers that are currently
-   waiting to be rebalanced after joiining a cluster or being reactivated after
+   waiting to be rebalanced after joining a cluster or being reactivated after
    failover.
 
 <a id="couchbase-admin-web-console-server-nodes"></a>
@@ -349,7 +349,7 @@ and the cluster as a whole.
 
 The `Data Buckets` page displays a list of all the configured buckets on your
 system (of both Couchbase and memcached types). The page provides a quick
-overview of your cluser health from the perspective of the configured buckets,
+overview of your cluster health from the perspective of the configured buckets,
 rather than whole cluster or individual servers.
 
 The information is shown in the form of a table, as seen in the figure below.
@@ -603,7 +603,7 @@ all the graphs and statistics display within the web console.
 
    The `Data Buckets` selection list allows you to select which of the buckets
    configured on your cluster is to be used as the basis for the graph display. The
-   statistics shown are agregated over the whole cluster for the selected bucket.
+   statistics shown are aggregated over the whole cluster for the selected bucket.
 
  * `Server Selection`
 
@@ -631,7 +631,7 @@ all the graphs and statistics display within the web console.
  * `Individual Server Selection`
 
    Clicking the blue triangle next to any of the smaller statistics graphs enables
-   you to show the selected statistic individuall for each server within the
+   you to show the selected statistic individual for each server within the
    cluster, instead of aggregating the information for the entire cluster.
 
 <a id="couchbase-admin-web-console-data-buckets-individual"></a>
@@ -1077,7 +1077,7 @@ configuration. Possible include:
  * **Starting Up**
 
    The replication process has just started, and the clusters are determining what
-   data needs to be sent from the originatin cluster to the destination cluster.
+   data needs to be sent from the originating cluster to the destination cluster.
 
  * **Replicating**
 
@@ -1211,7 +1211,7 @@ The statistics shown are:
 
  * `sets per sec.`
 
-   Set operations per second for incoming XDRC data.
+   Set operations per second for incoming XDCR data.
 
  * `deletes per sec.`
 
@@ -1377,7 +1377,7 @@ Once you have edited your `map()` and `reduce()` functions, you must use the
 `Save` button to save the view definition.
 
 The design document will be validated before it is created or updated in the
-system. The validation checks for valid Javascript and for the use of valid
+system. The validation checks for valid JavaScript and for the use of valid
 built-in reduce functions. Any validation failure is reported as an error.
 
 You can also save the modified version of your view as a new view using the
@@ -1577,7 +1577,7 @@ Failover](#couchbase-admin-tasks-failover-automatic).
 
 ### Enabling Alerts
 
-You can enable email alerts to be raised when a signficant error occurs on your
+You can enable email alerts to be raised when a significant error occurs on your
 Couchbase Server cluster. The email alert system works by sending email directly
 to a configured SMTP server. Each alert email is send to the list of configured
 email recipients.
@@ -1674,7 +1674,7 @@ The available settings are:
 
     * `Writing data to disk for a specific bucket has failed`
 
-      The disk or device used for persisting data has failed to store persitent data
+      The disk or device used for persisting data has failed to store persistent data
       for a bucket.
 
 
@@ -1786,7 +1786,7 @@ information to the Couchbase server:
  * Basic information about the size and configuration of your Couchbase cluster.
    This information will be used to help us prioritize our development efforts.
 
-You can enable/disable software updaate notifications
+You can enable/disable software update notifications
 
 The process occurs within the browser accessing the web console, not within the
 server itself, and no further configuration or internet access is required on

--- a/content/couchbase-manual-2.2/views-and-indexes.markdown
+++ b/content/couchbase-manual-2.2/views-and-indexes.markdown
@@ -799,7 +799,7 @@ The `meta` structure contains the following fields and associated information:
  * `expiration`
 
    The expiration value for the stored object. The stored expiration time is always
-   sotred as an absolute Unix epoch time value.
+   stored as an absolute Unix epoch time value.
 
 These additional fields are only exposed when processing the documents within
 the view server. These fields are not returned when you access the object
@@ -1035,7 +1035,7 @@ two parts, a map function and a reduce function:
 The combination of the map and the reduce function produce the corresponding
 view. The two functions work together, with the map producing the initial
 material based on the content of each JSON document, and the reduce function
-summarising the information generated during the map phase. The reduction
+summarizing the information generated during the map phase. The reduction
 process is selectable at the point of accessing the view, you can choose whether
 to the reduce the content or not, and, by using an array as the key, you can
 specifying the grouping of the reduce information.
@@ -1502,7 +1502,7 @@ The `reduce()` function has to work slightly differently to the `map()`
 function. In the primary form, a `reduce()` function must convert the data
 supplied to it from the corresponding `map()` function.
 
-The core structure of the reduce function execution is shown the figurebelow.
+The core structure of the reduce function execution is shown the figure below.
 
 
 ![](images/custom-reduce.png)
@@ -1630,7 +1630,7 @@ This can be explicitly written as follows:
 f(keys, values) = f(keys, [ f(keys, values) ])
 ```
 
-This can been seen graphically in the illustrationbelow, where previous
+This can been seen graphically in the illustration below, where previous
 reductions are included within the array of information are re-supplied to the
 reduce function as an element of the array of values supplied to the reduce
 function.
@@ -2206,7 +2206,7 @@ In the above example:
    The view being accessed in this case is a development view. To create a
    development view, you *must* use the `dev_` prefix to the view name.
 
-   As a `PUT` command, the URL is also significant, in that the location designes
+   As a `PUT` command, the URL is also significant, in that the location designates
    the name of the design document. In the example, the URL includes the name of
    the bucket ( `sales` ) and the name of the design document that will be created
    `dev_byfield`.
@@ -2227,7 +2227,7 @@ will contain the field `ok` and the ID of the design document created:
 ```
 
 The design document will be validated before it is created or updated in the
-system. The validation checks for valid Javascript and for the use of valid
+system. The validation checks for valid JavaScript and for the use of valid
 built-in reduce functions. Any validation failure is reported as an error.
 
 In the event of an error, the returned JSON will include the field `error` with
@@ -2436,7 +2436,7 @@ sequence and precedence of the different parameters during queries is shown in
 ![](images/views-query-flow.png)
 
 The core arguments and selection systems are the same through both the REST API
-interface, and the client libraries. The setting of these values differes
+interface, and the client libraries. The setting of these values differs
 between different client libraries, but the argument names and expected and
 supported values are the same across all environments.
 
@@ -2768,7 +2768,7 @@ records, including "aa":
 ```
 
 Specifying a partial string to `startkey` will trigger output of the selected
-values as soon as the first value or value greather than the specified value is
+values as soon as the first value or value greater than the specified value is
 identified. For strings, this partial match (from left to right) is identified.
 For example, specifying a `startkey` of "d" will return:
 
@@ -2789,7 +2789,7 @@ used. For example, searching a database of ingredients and specifying a
 To match all of the records for a given word or value across the entire range,
 you can use the null value in the `endkey` parameter. For example, to search for
 all records that start only with the word "almond", you specify a `startkey` of
-"almond", and an endkey of "almond\u02ad" (i.e. with the last latin character at
+"almond", and an endkey of "almond\u02ad" (i.e. with the last Latin character at
 the end). If you are using Unicode strings, you may want to use "\uefff".
 
 
@@ -3232,7 +3232,7 @@ responses during a view query.
     }
     ```
 
-   You can alter this behaviour by using the `on_error` argument. The default value
+   You can alter this behavior by using the `on_error` argument. The default value
    is `continue`. If you set this value to `stop` then the view response will cease
    the moment an error occurs. The returned JSON will contain the error information
    for the node that returned the first error. For example:
@@ -3668,7 +3668,7 @@ function(doc, meta) {
 ```
 
 For convenience, you may wish to use the `dateToArray()` function, which
-convertes a date object or string into an array. For example, if the date has
+converts a date object or string into an array. For example, if the date has
 been stored within the document as a single field:
 
 
@@ -4834,7 +4834,7 @@ request. The full list is provided in the following summary table.
                             | `ok` : Allow stale views                                            
                             | `update_after` : Allow stale view, update view after access         
 
-Bounding Box QueriesIf you do not supply a bounding box, the full dataset is
+Bounding Box Queries If you do not supply a bounding box, the full dataset is
 returned. When querying a spatial index you can use the bounding box to specify
 the boundaries of the query lookup on a given value. The specification should be
 in the form of a comma-separated list of the coordinates to use during the


### PR DESCRIPTION
Corrected typos and other minor issues in Couchbase Manual 2.2
