### PR TITLE
cleanup

### DIFF
--- a/content/couchbase-manual-2.1/administration-basics.markdown
+++ b/content/couchbase-manual-2.1/administration-basics.markdown
@@ -37,8 +37,8 @@ paths:
 Platform | Directory                                                       
 ---------|-----------------------------------------------------------------
 Linux    | `/opt/couchbase/var/lib/couchbase/data`                         
-Windows  | `C:\Program Files\couchbase\server\var\lib\couchbase\data`      
-Mac OS X | `~/Library/Application Support/Couchbase/var/lig/couchbase/data`
+Windows  | `C:\Program Files\couchbase\server\var\lib\couchbase\data`      
+Mac OS X | `~/Library/Application Support/Couchbase/var/lig/couchbase/data`
 
 [This path can be changed for each node at setup either via the Web UI setup
 wizard, using theREST API](#couchbase-admin-restapi) or using the Couchbase CLI:
@@ -113,7 +113,7 @@ On Linux, Couchbase Server is installed as a standalone application with support
 for running as a background (daemon) process during startup through the use of a
 standard control script, `/etc/init.d/couchbase-server`. The startup script is
 automatically installed during installation from one of the Linux packaged
-releases (Debian/Ubuntu or RedHat/CentOS). By default Couchbase Server is
+releases (Debian/Ubuntu or Red Hat/CentOS). By default Couchbase Server is
 configured to be started automatically at run levels 2, 3, 4, and 5, and
 explicitly shutdown at run levels 0, 1 and 6.
 
@@ -187,7 +187,7 @@ shell> C:\Program Files\Couchbase\Server\bin\service_stop.bat
 
 On Mac OS X, Couchbase Server is supplied as a standard application. You can
 start Couchbase Server by double clicking on the application. Couchbase Server
-runs as a background application which installs a menubar item through which you
+runs as a background application which installs a menu bar item through which you
 can control the server.
 
 

--- a/content/couchbase-manual-2.1/administration-tasks.markdown
+++ b/content/couchbase-manual-2.1/administration-tasks.markdown
@@ -815,7 +815,7 @@ Make sure you perform compaction…
    compaction should be scheduled during off-peak hours (use auto-compact to
    schedule specific times).
 
-   If compaction isn’t scheduled during off-peak hours, it can cause problems.
+   If compaction isn't scheduled during off-peak hours, it can cause problems.
    Because the compaction process can take a long to complete on large and busy
    databases, it is possible for the compaction process to fail to complete
    properly while the database is still active. In extreme cases, this can lead to
@@ -907,7 +907,7 @@ specific settings are identical:
 
    For example, if you set the fragmentation percentage at 10%, the moment the
    fragmentation level has been identified, the compaction process will be started,
-   unless you have time limited auto-compaction. SeeTime Period.
+   unless you have time limited auto-compaction. See Time Period.
 
  * **View Fragmentation**
 
@@ -1186,7 +1186,7 @@ failover is not without potential problems.
 
  * **External monitoring**
 
-   [Another option is to have a system monitoring the cluster via theManagement
+   [Another option is to have a system monitoring the cluster via the Management
    REST API](#couchbase-admin-restapi). Such an external system is in a good
    position to failover nodes because it can take into account system components
    that are outside the scope of Couchbase Server.
@@ -1414,7 +1414,7 @@ There are a number of methods for performing a backup:
    For more information, see [Backing Up Using File
    Copies](#couchbase-backup-restore-backup-filecopy).
 
-   [To restore, you need to use thefile copy](#couchbase-backup-restore-filecopy)
+   [To restore, you need to use the file copy](#couchbase-backup-restore-filecopy)
    method.
 
 Due to the active nature of Couchbase Server it is impossible to create a
@@ -2444,7 +2444,7 @@ be updated or upgraded.
 
 Before you remove a node from the cluster, you should ensure that you have the
 capacity within the remaining nodes of your cluster to handle your workload. For
-more information on the considerations, seeChoosing when to shrink your cluster.
+more information on the considerations, see Choosing when to shrink your cluster.
 For the best results, use swap rebalance to swap the node you want to remove
 out, and swap in a replacement node. For more information on swap rebalance, see
 [Swap Rebalance](#couchbase-admin-tasks-addremove-rebalance-swap).
@@ -2623,7 +2623,7 @@ The benefits of swap rebalance are:
    the capacity of the cluster remains unchanged during the rebalance operation,
    helping to ensure performance and failover support.
 
-The behaviour of the cluster during a failover and rebalance operation with the
+The behavior of the cluster during a failover and rebalance operation with the
 swap rebalance functionality affects the following situations:
 
  * **Stopping a rebalance**
@@ -2987,7 +2987,7 @@ each Couchbase Server node.
 
 ### XDCR Architecture
 
-There are a number of key elements in Couchbase Server’s XDCR architecture
+There are a number of key elements in Couchbase Server's XDCR architecture
 including:
 
 **Continuous Replication.** XDCR in Couchbase Server provides continuous
@@ -3027,12 +3027,12 @@ replicated.
 **Active-Active Conflict Resolution.** Within a cluster, Couchbase Server
 provides strong consistency at the document level. On the other hand, XDCR also
 provides eventual consistency across clusters. Built-in conflict resolution will
-pick the same “winner” on both the clusters if the same document was mutated on
+pick the same "winner" on both the clusters if the same document was mutated on
 both the clusters. If a conflict occurs, the document with the most updates will
-be considered the “winner.” If the same document is updated the same number of
+be considered the "winner." If the same document is updated the same number of
 times on the source and destination, additional metadata such as numerical
 sequence, CAS value, document flags and expiration TTL value are used to pick
-the “winner.” XDCR applies the same rule across clusters to make sure document
+the "winner." XDCR applies the same rule across clusters to make sure document
 consistency is maintained:
 
 
@@ -3233,7 +3233,7 @@ Settings](#couchbase-admin-restapi-xdcr-internal-settings).
 
 <a id="couchbase-admin-tasks-xdcr-cancellation"></a>
 
-### Cancelling Replication
+### Canceling Replication
 
 You can cancel replication at any time by clicking `Delete` next to the active
 replication that is to be canceled.
@@ -3591,7 +3591,7 @@ To change the disk path of the existing node, the recommended sequence is:
 
  1. Configure the new disk path, either by using the REST API (see [Configuring
     Index Path for a Node](#couchbase-admin-restapi-provisioning-diskpath) ), using
-    the command-line (seecluster initializationfor more information).
+    the command-line (see cluster initialization for more information).
 
     Alternatively, connect to the Web UI of the new node, and follow the setup
     process to configure the disk path (see [Initial Server

--- a/content/couchbase-manual-2.1/appendix-couchbase-sample-buckets.markdown
+++ b/content/couchbase-manual-2.1/appendix-couchbase-sample-buckets.markdown
@@ -236,7 +236,7 @@ The primary document type is the 'beer' document:
 ```
 
 Beer documents contain core information about different beers, including the
-name, alcohol by volume ( `abv` ) and categorisation data.
+name, alcohol by volume ( `abv` ) and categorization data.
 
 Individual beer documents are related to brewery documents using the
 `brewery_id` field, which holds the information about a specific brewery for the
@@ -265,8 +265,8 @@ beer:
 }
 ```
 
-The brewery reconrd includes basic contact and address information for the
-brewery, and contains a spatial record consisting of the latitute and longitude
+The brewery record includes basic contact and address information for the
+brewery, and contains a spatial record consisting of the latitude and longitude
 of the brewery location.
 
 To demonstrate the view functionality in Couchbase Server, three views are

--- a/content/couchbase-manual-2.1/appendix-faqs.markdown
+++ b/content/couchbase-manual-2.1/appendix-faqs.markdown
@@ -16,14 +16,14 @@
 
    A TAP stream is a when a client requests a stream of item updates from the
    server. That is, as other clients are requesting item mutations (for example,
-   SET's and DELETE's), a TAP stream client can "wire-tap" the server to receive a
+   SETs and DELETEs), a TAP stream client can "wire-tap" the server to receive a
    stream of item change notifications.
 
    When a TAP stream client starts its connection, it may also optionally request a
    stream of all items stored in the server, even if no other clients are making
    any item changes. On the TAP stream connection setup options, a TAP stream
    client may request to receive just current items stored in the server (all items
-   until "now"), or all item changes from now onwards into in the future, or both.
+   until "now"), or all item changes from now onward into in the future, or both.
 
    Trond Norbye's written a blog post about the TAP interface. See [Blog
    Entry](http://blog.couchbase.com/want-know-what-your-memcached-servers-are-doing-tap-them).

--- a/content/couchbase-manual-2.1/appendix-release-notes.markdown
+++ b/content/couchbase-manual-2.1/appendix-release-notes.markdown
@@ -13,7 +13,7 @@ This release includes some major bug fixes and enhancements:
 
 **New Edition in 2.1.1**
 
-The Enterprise Edition of Couchbase Server is now available on Mac OSX. See
+The Enterprise Edition of Couchbase Server is now available on Mac OS X. See
 [Couchbase, Downloads](http://www.couchbase.com/download).
 
 **Fixes in 2.1.1**

--- a/content/couchbase-manual-2.1/appendix-troubleshooting-views-technical-background-.markdown
+++ b/content/couchbase-manual-2.1/appendix-troubleshooting-views-technical-background-.markdown
@@ -539,7 +539,7 @@ The documents included in each row don't match the value field of each row, that
 is, the documents included are the latest (updated) versions but the index row
 values still reflect the previous (first) version of the documents.
 
-Why this behaviour? Well, `include_docs=true` works by at query time, for each
+Why this behavior? Well, `include_docs=true` works by at query time, for each
 row, to fetch from disk the latest revision of each document. There's no way to
 include a previous revision of a document. Previous revisions are not accessible
 through the latest vbucket databases MVCC snapshots (
@@ -553,7 +553,7 @@ The only way to ensure full consistency here is to include the documents
 themselves in the values emitted by the map function. Queries with `stale=false`
 are not 100% reliable either, as just after the index is updated and while rows
 are being streamed from disk to the client, document updates and deletes can
-still happen, resulting in the same behaviour as in the given example.
+still happen, resulting in the same behavior as in the given example.
 
 <a id="couchbase-views-debugging-expired"></a>
 
@@ -882,7 +882,7 @@ as `couch_dbinfo` and `couch_dbdump` to analyze active vbucket database files.
 Before looking at those tools, lets first know what database sequence numbers
 are.
 
-When a couchdb database (remember, each corresponds to a vbucket) is created,
+When a CouchDB database (remember, each corresponds to a vbucket) is created,
 its update\_seq (update sequence number) is 0. When a document is created,
 updated or deleted, its current sequence number is incremented by 1. So all the
 following sequence of actions result in the final sequence number of 5:
@@ -2104,7 +2104,7 @@ the following information to JIRA issues:
  * If you generated the data with any tool, mention its name and all the parameters
    given to it (full command line)
 
- * Show what queries you were doing (include all query parameters, full url), use
+ * Show what queries you were doing (include all query parameters, full URL), use
    curl with option -v and show the full output, example:
 
 

--- a/content/couchbase-manual-2.1/appendix-uninstalling-couchbase-server.markdown
+++ b/content/couchbase-manual-2.1/appendix-uninstalling-couchbase-server.markdown
@@ -18,16 +18,16 @@ Before removing Couchbase Server from your system, you should do the following:
 
 <a id="couchbase-uninstalling-redhat"></a>
 
-## Uninstalling on a RedHat Linux System
+## Uninstalling on a Red Hat Linux System
 
-To uninstall the software on a RedHat Linux system, run the following command:
+To uninstall the software on a Red Hat Linux system, run the following command:
 
 
 ```
 shell> sudo rpm -e couchbase-server
 ```
 
-Refer to the RedHat RPM documentation for more information about uninstalling
+Refer to the Red Hat RPM documentation for more information about uninstalling
 packages using RPM.
 
 You may need to delete the data files associated with your installation. The

--- a/content/couchbase-manual-2.1/best-practices.markdown
+++ b/content/couchbase-manual-2.1/best-practices.markdown
@@ -39,7 +39,7 @@ Cloud](#couchbase-bestpractice-cloud).
    because of the drawback: if a server receives a client request and doesn't have
    the requested data, there's an additional hop. Read more about clients
    [here](http://www.couchbase.com/develop). Read more about different Deployment
-   Strategieshere](#couchbase-deployment).
+   Strategies here](#couchbase-deployment).
 
  * Number of cores: Couchbase is relatively more memory or I/O bound than is CPU
    bound. However, Couchbase is more efficient on machines that have at least two
@@ -149,7 +149,7 @@ Constant                                                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Metadata per document (metadata\_per\_document)                                                                                                                                                  | This is the amount of memory that Couchbase needs to store metadata per document. Prior to Couchbase 2.1, metadata used 64 bytes. As of Couchbase 2.1, metadata uses 56 bytes. All the metadata needs to live in memory while a node is running and serving data.
 SSD or Spinning                                                                                                                                                                                  | SSDs give better I/O performance.                                                                                                                                                                                                                                
-headroomThe cluster needs additonal overhead to store metadata. That space is called the headroom. This requires approximately 25-30% more space than the raw RAM requirements for your dataset. | Since SSDs are faster than spinning (traditional) hard disks, you should set aside 25% of memory for SSDs and 30% of memory for spinning hard disks.                                                                                                             
+headroom The cluster needs additional overhead to store metadata. That space is called the headroom. This requires approximately 25-30% more space than the raw RAM requirements for your dataset. | Since SSDs are faster than spinning (traditional) hard disks, you should set aside 25% of memory for SSDs and 30% of memory for spinning hard disks.                                                                                                             
 High Water Mark (high\_water\_mark)                                                                                                                                                              | By default, the high water mark for a node's RAM is set at 70%.                                                                                                                                                                                                  
 
 This is a rough guideline to size your cluster:
@@ -360,7 +360,7 @@ primary concerns for your servers, here is what we recommend:
       throughput.
 
  * Network: Most configurations will work with Gigabit Ethernet interfaces. Faster
-   solutions such as 10GBit and Inifiniband will provide spare capacity.
+   solutions such as 10GBit and Infiniband will provide spare capacity.
 
 <a id="couchbase-bestpractice-sizing-cloud"></a>
 
@@ -449,7 +449,7 @@ following:
 [The water mark is another key statistic to monitor cluster performance. The
 'water mark' determines when it is necessary to start freeing up available
 memory. Read more about this
-concepthere](#couchbase-introduction-architecture-diskstorage). Here are two
+concept here](#couchbase-introduction-architecture-diskstorage). Here are two
 important statistics related to water marks:
 
  * High Water Mark ( `ep_mem_high_wat` )
@@ -710,7 +710,7 @@ are moved to the swap space. From a range of 0 to 100, swappiness indicates how
 frequently a system should use swap space based on RAM usage. We recommend the
 following for swap space:
 
- * By default on most Linux platforms, swapiness is set to 60. However this will
+ * By default on most Linux platforms, swappiness is set to 60. However this will
    make a system go into swap too frequently for Couchbase Server.
 
  * If you use Couchbase Server 2.0+ without views, we recommend setting swappiness

--- a/content/couchbase-manual-2.1/command-line-interface-for-administration.markdown
+++ b/content/couchbase-manual-2.1/command-line-interface-for-administration.markdown
@@ -25,8 +25,8 @@ each platform:
 
 **Linux**    | `/opt/couchbase/bin`, `/opt/couchbase/bin/install`, `/opt/couchbase/bin/tools`, `/opt/couchbase/bin/tools/unsupported`                      
 -------------|---------------------------------------------------------------------------------------------------------------------------------------------
-**Windows**  | `C:\Program Files\couchbase\server\bin`, `C:\Program Files\couchbase\server\bin\install`, and `C:\Program Files\couchbase\server\bin\tools`.
-**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin`                                                                  
+**Windows**  | `C:\Program Files\couchbase\server\bin`, `C:\Program Files\couchbase\server\bin\install`, and `C:\Program Files\couchbase\server\bin\tools`.
+**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin`                                                                  
 
 <a id="couchbase-admin-cmdline-unsupported"></a>
 
@@ -99,8 +99,8 @@ cluster have access to.
 
 **Linux**    | `/opt/couchbase/bin/couchbase-cli`                                                      
 -------------|-----------------------------------------------------------------------------------------
-**Windows**  | `C:\Program Files\Couchbase\Server\bin\couchbase-cli.exe`                               
-**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/couchbase-cli`
+**Windows**  | `C:\Program Files\Couchbase\Server\bin\couchbase-cli.exe`                               
+**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/couchbase-cli`
 
 This tool provides access to various management operations for Couchbase Server
 clusters, nodes and buckets. The basic usage format is:
@@ -211,7 +211,7 @@ Command                | Option                                     | Descriptio
 `setting-compacttion`  | `--compaction-db-size=SIZE[MB]`            | Size of disk fragmentation when database compaction is triggered        
 `setting-compacttion`  | `--compaction-view-percentage=PERCENTAGE`  | Percentage of disk fragmentation when views compaction is triggered     
 `setting-compacttion`  | `--compaction-view-size=SIZE[MB]`          | Size of disk fragmentation when views compaction is triggered           
-`setting-compacttion`  | `--compaction-period-from=HH:MM`           | Enable compaction from this time onwards                                
+`setting-compacttion`  | `--compaction-period-from=HH:MM`           | Enable compaction from this time onward                                
 `setting-compacttion`  | `--compaction-period-to=HH:MM`             | Stop enabling compaction at this time                                   
 `setting-compacttion`  | `--enable-compaction-abort=[0|1]`          | Allow compaction to abort when time expires                             
 `setting-compacttion`  | `--enable-compaction-parallel=[0|1]`       | Allow parallel compaction processes for database and view               
@@ -219,7 +219,7 @@ Command                | Option                                     | Descriptio
 `setting-notification` | `--enable-notification=[0|1]`              | Allow notifications                                                     
                        |                                            |                                                                         
 `setting-alert`        | `--enable-email-alert=[0|1]`               | Allow email alert                                                       
-`setting-alert`        | `--email-recipients=RECIPIENT`             | Email recipents, separate addresses with, or ;                          
+`setting-alert`        | `--email-recipients=RECIPIENT`             | Email recipients, separate addresses with, or ;                          
 `setting-alert`        | `--email-sender=SENDER`                    | Sender email address                                                    
 `setting-alert`        | `--email-user=USER`                        | Email server username                                                   
 `setting-alert`        | `--email-password=PWD`                     | Email server password                                                   
@@ -257,7 +257,7 @@ Command                | Option                                     | Descriptio
 `xdcr-replicate`       | `--create`                                 | Create and start a new replication                                      
 `xdcr-replicate`       | `--delete`                                 | Stop and cancel a replication                                           
 `xdcr-replicate`       | `--xdcr-from-bucket=BUCKET`                | Source bucket name to replicate from                                    
-`xdcr-replicate`       | `--xdcr-clucter-name=CLUSTERNAME`          | Remote cluster to replicate to                                          
+`xdcr-replicate`       | `--xdcr-cluster-name=CLUSTERNAME`          | Remote cluster to replicate to                                          
 `xdcr-replicate`       | `--xdcr-to-bucket=BUCKETNAME`              | Remote bucket to replicate to                                           
 
 You can also perform many of these same settings using the REST-API, see [Using
@@ -462,8 +462,8 @@ locations, depending on your platform:
 
 **Linux**    | `/opt/couchbase/bin/cbstats`                                                      
 -------------|-----------------------------------------------------------------------------------
-**Windows**  | `C:\Program Files\Couchbase\Server\bin\cbstats.exe`                               
-**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/cbstats`
+**Windows**  | `C:\Program Files\Couchbase\Server\bin\cbstats.exe`                               
+**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/cbstats`
 
 
 
@@ -475,7 +475,7 @@ node. If you want to perform this operation for an entire cluster, you will need
 to perform the command for every node/bucket combination that exists for that
 cluster.
 
-[You use this tool to get thecouchbase node
+[You use this tool to get the Couchbase Server node
 statistics](#couchbase-monitoring-nodestats). The general format for the command
 is:
 
@@ -564,13 +564,13 @@ ep\_num\_ops\_del\_meta            | Number of delWithMeta operations
 curr\_items                        | Num items in active vbuckets (temp + live)                                                                                                                                       
 curr\_temp\_items                  | Num temp items in active vbuckets                                                                                                                                                
 curr\_items\_tot                   | Num current items including those not active (replica, dead and pending states)                                                                                                  
-ep\_kv\_size                       | Memory used to store item metadata, keys and values, no matter the vbucket’s state. If an item’s value is ejected, this stat will be decremented by the size of the item’s value.
+ep\_kv\_size                       | Memory used to store item metadata, keys and values, no matter the vbucket's state. If an item's value is ejected, this stat will be decremented by the size of the item's value.
 ep\_value\_size                    | Memory used to store values for resident keys                                                                                                                                    
 ep\_overhead                       | Extra memory used by transient data like persistence queues, replication queues, checkpoints, etc.                                                                               
 ep\_max\_data\_size                | Max amount of data allowed in memory.                                                                                                                                            
 ep\_mem\_low\_wat                  | Low water mark for auto-evictions.                                                                                                                                               
 ep\_mem\_high\_wat                 | High water mark for auto-evictions.                                                                                                                                              
-ep\_total\_cache\_size             | The total byte size of all items, no matter the vbucket’s state, no matter if an item’s value is ejected.                                                                        
+ep\_total\_cache\_size             | The total byte size of all items, no matter the vbucket's state, no matter if an item's value is ejected.                                                                        
 ep\_oom\_errors                    | Number of times unrecoverable OOMs happened while processing operations                                                                                                          
 ep\_tmp\_oom\_errors               | Number of times temporary OOMs happened while processing operations                                                                                                              
 ep\_mem\_tracker\_enabled          | True if memory usage tracker is enabled                                                                                                                                          
@@ -884,8 +884,8 @@ cluster restart.
 
 **Linux**    | `/opt/couchbase/bin/cbepctl`                                                      
 -------------|-----------------------------------------------------------------------------------
-**Windows**  | `C:\Program Files\Couchbase\Server\bin\cbepctl.exe`                               
-**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/cbepctl`
+**Windows**  | `C:\Program Files\Couchbase\Server\bin\cbepctl.exe`                               
+**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/cbepctl`
 
 **Be aware that this tool is a per-node, per-bucket operation.** That means that
 if you want to perform this operation, you must specify the IP address of a node
@@ -1266,8 +1266,8 @@ platform:
 
 **Linux**    | `/opt/couchbase/bin/cbcollect_info`                                                      
 -------------|------------------------------------------------------------------------------------------
-**Windows**  | `C:\Program Files\Couchbase\Server\bin\cbcollect_info`                                   
-**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/cbcollect_info`
+**Windows**  | `C:\Program Files\Couchbase\Server\bin\cbcollect_info`                                   
+**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/cbcollect_info`
 
 **Be aware that this tool is a per-node operation.** If you want to perform this
 operation for an entire cluster, you will need to perform the command for every
@@ -1353,8 +1353,8 @@ Depending upon your platform, this tool is the following directories:
 
 **Linux**    | `/opt/couchbase/bin/cbbackup`                                                      
 -------------|------------------------------------------------------------------------------------
-**Windows**  | `C:\Program Files\Couchbase\Server\bin\cbbackup`                                   
-**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/cbbackup`
+**Windows**  | `C:\Program Files\Couchbase\Server\bin\cbbackup`                                   
+**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/cbbackup`
 
 The format of the `cbbackup` command is:
 
@@ -1612,8 +1612,8 @@ The tool is in the following locations, depending on your platform:
 
 **Linux**    | `/opt/couchbase/bin/cbrestore`                                                      
 -------------|-------------------------------------------------------------------------------------
-**Windows**  | `C:\Program Files\Couchbase\Server\bin\cbrestore`                                   
-**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/cbrestore`
+**Windows**  | `C:\Program Files\Couchbase\Server\bin\cbrestore`                                   
+**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/cbrestore`
 
 The format of the `cbrestore` command is:
 
@@ -1640,7 +1640,7 @@ Where:
 
  * `[destination]`
 
-   The destination bucket for the restored information. This is a bucker in an
+   The destination bucket for the restored information. This is a bucket in an
    existing cluster. If you restore the data to a single node in a cluster, provide
    the hostname and port for the node you want to restore to. If you restore an
    entire data bucket, provide the URL of one of the nodes within the cluster.
@@ -1712,7 +1712,7 @@ default port of `8091`. The default number of vBuckets for Couchbase 2.0 is
 1024; in earlier versions of Couchbase, you may have a different number of
 vBuckets. If you do want to restore data to a cluster with a different number of
 vBuckets, you should perform this command with port `11211`, which will
-accomodate the difference in vBuckets:
+accommodate the difference in vBuckets:
 
 
 ```
@@ -1753,8 +1753,8 @@ Locations for this tool are as follows:
 
 **Linux**    | `/opt/couchbase/bin/`                                                      
 -------------|----------------------------------------------------------------------------
-**Windows**  | `C:\Program Files\Couchbase\Server\bin\`                                   
-**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/`
+**Windows**  | `C:\Program Files\Couchbase\Server\bin\`                                   
+**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/`
 
 The following is the syntax and examples for this command:
 
@@ -1980,7 +1980,7 @@ that must be addressed immediately.
 [The tool retrieves data from the Couchbase Server monitoring system, aggregates
 it over a time scale, analyzes the statistics against thresholds, and generates
 a report. Unlike other command line tools such as `cbstats` and `cbtransfer`
-that use theTAP protocol](#couchbase-introduction-architecture-tap) to obtain
+that use the TAP protocol](#couchbase-introduction-architecture-tap) to obtain
 data from the monitoring system, `cbhealthchecker` obtains data by using the
 REST API and the memcached protocol. For more information about the statistics
 provided by Couchbase Server, see [Statistics and
@@ -2002,8 +2002,8 @@ platform:
 
 **Linux**    | `/opt/couchbase/bin/`                                                      
 -------------|----------------------------------------------------------------------------
-**Windows**  | `C:\Program Files\Couchbase\Server\bin\`                                   
-**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/`
+**Windows**  | `C:\Program Files\Couchbase\Server\bin\`                                   
+**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/`
 
 The format of the `cbhealthchecker` command is:
 
@@ -2172,8 +2172,8 @@ depending upon your platform:
 
 **Linux**    | `/opt/couchbase/bin/tools/`                                                      
 -------------|----------------------------------------------------------------------------------
-**Windows**  | `C:\Program Files\Couchbase\Server\bin\tools\`                                   
-**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/tools/`
+**Windows**  | `C:\Program Files\Couchbase\Server\bin\tools\`                                   
+**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/tools/`
 
 When you load documents as well as any associated design documents for views,
 you should use a directory structure similar to the following:
@@ -2229,8 +2229,8 @@ This is useful for testing your Couchbase node.
 
 **Linux**    | `/opt/couchbase/bin/tools/`                                                      
 -------------|----------------------------------------------------------------------------------
-**Windows**  | `C:\Program Files\Couchbase\Server\bin\tools\`                                   
-**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/tools/`
+**Windows**  | `C:\Program Files\Couchbase\Server\bin\tools\`                                   
+**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/tools/`
 
 The following is the standard command format:
 
@@ -2290,7 +2290,7 @@ upon your platform, this tool is at the following locations:
 **Linux**    | `/opt/couchbase/bin/tools/`                                                      
 -------------|----------------------------------------------------------------------------------
 **Windows**  | Not Available on this platform.                                                  
-**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/tools/`
+**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/tools/`
 
 <a id="couchbase-admin-cmdline-vbuckettool"></a>
 
@@ -2304,7 +2304,7 @@ values based on Couchbase Server internal hashing algorithm. Moved as of 1.8 to
 
 **Linux**    | `/opt/couchbase/bin/tools/`                                                      
 -------------|----------------------------------------------------------------------------------
-**Windows**  | `C:\Program Files\Couchbase\Server\bin\tools\`                                   
-**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/tools/`
+**Windows**  | `C:\Program Files\Couchbase\Server\bin\tools\`                                   
+**Mac OS X** | `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/tools/`
 
 <a id="couchbase-admin-restapi"></a>

--- a/content/couchbase-manual-2.1/installing-and-upgrading.markdown
+++ b/content/couchbase-manual-2.1/installing-and-upgrading.markdown
@@ -23,7 +23,7 @@ To start using Couchbase Server, you need to follow these steps:
 ## Preparation
 
 Mixed deployments, such as cluster with both Linux and Windows server nodes are
-not supported. This incomparability is due to differences in the number of
+not supported. This incompatibility is due to differences in the number of
 shards between platforms. It is not possible either to mix operating systems
 within the same cluster, or configure XDCR between clusters on different
 platforms. You should use same operating system on all machines within a cluster
@@ -51,11 +51,11 @@ Windows 2008             | R2 with SP1 | 64 bit          | Developer and Product
 Windows 2012             |             | 64 bit          | Developer only           |                        
 Windows 7                |             | 64 bit          | Developer only           |                        
 Windows 8                |             | 64 bit          | Developer only           |                        
-MacOS                    | 10.7        | 64 bit          | Developer only           |                        
-MacOS                    | 10.8        | 64 bit          | Developer only           | MacOS 10.8             
+Mac OS                    | 10.7        | 64 bit          | Developer only           |                        
+Mac OS                    | 10.8        | 64 bit          | Developer only           | Mac OS 10.8             
 
 **Couchbase clusters with mixed platforms are not supported.** Specifically,
-Couchbase Server on MacOSX uses 64 vBuckets as opposed to the 1024 vBuckets used
+Couchbase Server on Mac OS X uses 64 vBuckets as opposed to the 1024 vBuckets used
 by other platforms. Due to this difference, if you need to move data between a
 Mac OS X cluster and a cluster hosted on another platform use `cbbackup` and
 `cbrestore`. For more information, see [Backup and Restore Between Mac OS X and
@@ -117,7 +117,7 @@ Guidelines](#couchbase-bestpractice-sizing).
 
 ### Supported Web Browsers
 
-The Couchbase Web Console runs on the following browsers, with Javascript
+The Couchbase Web Console runs on the following browsers, with JavaScript
 support enabled:
 
  * Mozilla Firefox 3.6 or higher
@@ -214,9 +214,9 @@ To perform an upgrade installation while retaining your existing dataset, see
 ### Red Hat Linux Installation
 
 Before you install, make sure you check the supported platforms, see [Supported
-Platforms](#couchbase-getting-started-prepare-platforms). The RedHat
-installation uses the RPM package. Installation is supported on RedHat and
-RedHat-based operating systems such as CentOS.
+Platforms](#couchbase-getting-started-prepare-platforms). The Red Hat
+installation uses the RPM package. Installation is supported on Red Hat and
+Red Hat-based operating systems such as CentOS.
 
  1. For Red Hat Enterprise Linux version 6.0 and above, you need to install a
     specific OpenSSL dependency by running:
@@ -237,7 +237,7 @@ RedHat-based operating systems such as CentOS.
 
     Once the `rpm` command completes, Couchbase Server starts automatically, and is
     configured to automatically start during boot under the 2, 3, 4, and 5
-    runlevels. Refer to the RedHat RPM documentation for more information about
+    runlevels. Refer to the Red Hat RPM documentation for more information about
     installing packages using RPM.
 
     After installation finishes, the installation process will display a message
@@ -245,7 +245,7 @@ RedHat-based operating systems such as CentOS.
 
      ```
      Minimum RAM required  : 4 GB
-     System RAM configured : 8174464 kB
+     System RAM configured : 8174464 KB
 
      Minimum number of processors required : 4 cores
      Number of processors on the system    : 4 cores
@@ -264,9 +264,9 @@ RedHat-based operating systems such as CentOS.
      See /opt/couchbase/LICENSE.txt.
      ```
 
-Once installed, you can use the RedHat `chkconfig` command to manage the
+Once installed, you can use the Red Hat `chkconfig` command to manage the
 Couchbase Server service, including checking the current status and creating the
-links to enable and disable automatic start-up. Refer to the [RedHat
+links to enable and disable automatic start-up. Refer to the [Red Hat
 documentation](https://access.redhat.com/site/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/s2-services-chkconfig.html)
 for instructions.
 
@@ -312,7 +312,7 @@ Platforms](#couchbase-getting-started-prepare-platforms).
      Unpacking couchbase-server (from couchbase-server_x86_64_2.1.0-xxx-rel.deb) ...
      libssl0.9.8 is installed. Continue installing
      Minimum RAM required  : 4 GB
-     System RAM configured : 4058708 kB
+     System RAM configured : 4058708 KB
 
      Minimum number of processors required : 4 cores
      Number of processors on the system    : 4 cores
@@ -465,7 +465,7 @@ which contains a standalone application that can be copied to the `Applications`
 folder or to any other location you choose. The installation location is not the
 same as the location of the Couchbase data files.
 
-Please use the default archive file hander in Mac OS X, Archive Utility, when
+Please use the default archive file handler in Mac OS X, Archive Utility, when
 you unpack the Couchbase Server distribution. It is more difficult to diagnose
 non-functioning or damaged installations after extraction by other third party
 archive extraction tools.
@@ -513,7 +513,7 @@ fig-couchbase-getting-started-macosx-menubar**.
 The command line tools are included in the Couchbase Server application
 directory. You can access them in Terminal by using the full path of the
 Couchbase Server installation. By default, this is
-`/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/`.
+`/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/`.
 
 <a id="couchbase-getting-started-setup"></a>
 
@@ -607,7 +607,7 @@ port other than `8091`, go to that port.
     When you provide an email address we will add it to the Couchbase community
     mailing list for news and update information about Couchbase and related
     products. You can unsubscribe from the mailing list at any time using the
-    unsubscribe link provided in each newletter. Web Console communicates the
+    unsubscribe link provided in each newsletter. Web Console communicates the
     following information:
 
      * The current version. When a new version of Couchbase Server exists, you get
@@ -835,7 +835,7 @@ Tool](#couchbase-admin-cmdline-cbbackup).
      ```
 
  1. For 2.0, edit the script located at
-    `C:\Program Files\Couchbase\Server\bin\service_register.bat`. You do not need
+    `C:\Program Files\Couchbase\Server\bin\service_register.bat`. You do not need
     this step for 2.0.1.
 
      * On the 7th line it says: `set NS_NAME=ns_1@%IP_ADDR%`
@@ -844,7 +844,7 @@ Tool](#couchbase-admin-cmdline-cbbackup).
 
  1. Edit the IP address configuration file.
 
-    For Windows 2.0 edit `C:\Program Files\Couchbase\Server\var\lib\couchbase\ip`.
+    For Windows 2.0 edit `C:\Program Files\Couchbase\Server\var\lib\couchbase\ip`.
     This file contains the identified IP address of the node once it is part of a
     cluster. Open the file, and add a single line containing the `hostname`, as
     configured in the previous step.
@@ -853,10 +853,10 @@ Tool](#couchbase-admin-cmdline-cbbackup).
     Files\Couchbase\Server\var\lib\couchbase\ip_start.`
 
  1. Register the service by running the modified script:
-    `C:\Program Files\Couchbase\Server\bin\service_register.bat`
+    `C:\Program Files\Couchbase\Server\bin\service_register.bat`
 
  1. Delete the files located under:
-    `C:\Program Files\Couchbase\Server\var\lib\couchbase\mnesia`.
+    `C:\Program Files\Couchbase\Server\var\lib\couchbase\mnesia`.
 
  1. Start the service by running:
 
@@ -1187,7 +1187,7 @@ an individual nodes in a cluster remain the same:
     Platform | Location
     ---------|-------------------------------------------------------------------------------
     Linux    | `/opt/couchbase/var/lib/couchbase/config/config.dat`
-    Windows  | `C:\Program Files\Couchbase\Server\Config\var\lib\couchbase\config\config.dat`
+    Windows  | `C:\Program Files\Couchbase\Server\Config\var\lib\couchbase\config\config.dat`
 
  1. Stop Couchbase Server. For instructions, see [Server Startup and
     Shutdown](#couchbase-admin-basics-running).
@@ -1204,7 +1204,7 @@ an individual nodes in a cluster remain the same:
 
  1. Perform the installation upgrade for your platform:
 
-    **RHEL/Centos**
+    **RHEL/CentOS**
 
     You can perform an upgrade install using the RPM package — this will keep the
     data and existing configuration.
@@ -1225,7 +1225,7 @@ an individual nodes in a cluster remain the same:
 
     The Install Wizard will upgrade your server installation using the same
     installation location. For example, if you have installed Couchbase Server in
-    the default location, `C:\Program Files\Couchbase\Server`, the Couchbase Server
+    the default location, `C:\Program Files\Couchbase\Server`, the Couchbase Server
     installer will put the latest version at the same location.
 
 <a id="couchbase-getting-started-upgrade-1-8-2-0"></a>
@@ -1256,7 +1256,7 @@ rebalance may fail.
 When you upgrade from Couchbase Server 1.8 to Couchbase Server 2.1+ on Linux,
 you should be aware of the **OpenSSL** requirement. OpenSSL is a required
 component and you will get an error message during upgrade if it is not
-installed. To install it RedHat-based systems, use `yum` :
+installed. To install it Red Hat-based systems, use `yum` :
 
 
 ```
@@ -1278,10 +1278,10 @@ the IP and hostname configuration is correct both before the upgrade and after
 upgrading the software. See [Hostnames for Couchbase Server 2.0.1 and
 Earlier](#couchbase-getting-started-hostnames-pre2.0).
 
-**Mac OSX Notes for 1.8.1 to 2.1+**
+**Mac OS X Notes for 1.8.1 to 2.1+**
 
-There is currently no officially supported upgrade installer for Mac OSX. If you
-want to migrate to 1.8.1 to 2.1+ on OSX, you must make a backup of your data
+There is currently no officially supported upgrade installer for Mac OS X. If you
+want to migrate to 1.8.1 to 2.1+ on OS X, you must make a backup of your data
 files with `cbbackup`, install the latest version, then restore your data with
 `cbrestore`. For more information, see [cbbackup
 Tool](#couchbase-admin-cmdline-cbbackup) and [cbrestore

--- a/content/couchbase-manual-2.1/introduction-to-couchbase-server.markdown
+++ b/content/couchbase-manual-2.1/introduction-to-couchbase-server.markdown
@@ -290,7 +290,7 @@ Buckets](#couchbase-admin-web-console-data-buckets-createedit).
    caching data *for all buckets* and is configured on a per-node basis. The Server
    Quota is initially configured in the first server in your cluster is configured,
    and the quota is identical on all nodes. For example, if you have 10 nodes and a
-   16GB Server Quota, ther is 160GB RAM available across the cluster. If you were
+   16GB Server Quota, there is 160GB RAM available across the cluster. If you were
    to add two more nodes to the cluster, the new nodes would need 16GB of free RAM,
    and the aggregate RAM available in the cluster would be 192GB.
 
@@ -311,7 +311,7 @@ cluster expands the overall RAM quota, and the bucket quota, increasing the
 amount of information that can be kept in RAM.
 
 [The Bucket Quota is used by the system to determine when data should
-beejected](#couchbase-introduction-architecture-ejection-eviction) from memory.
+be ejected](#couchbase-introduction-architecture-ejection-eviction) from memory.
 Bucket Quotas are dynamically configurable within the limit of your Server
 Quota, and enable you to individually control the caching of information in
 memory on a per bucket basis. You can therefore configure different buckets to
@@ -336,8 +336,8 @@ data, and for supporting replicas (copies of bucket data) on more than one node.
 Clients access the information stored in a bucket by communicating directly with
 the node response for the corresponding vBucket. This direct access enables
 clients to communicate with the node storing the data, rather than using a proxy
-or redistribution architecture. The result is abstracting the physical toplogy
-from the logical partitioning of data. This architecture is what gives Coucbase
+or redistribution architecture. The result is abstracting the physical topology
+from the logical partitioning of data. This architecture is what gives Couchbase
 Server the elasticity.
 
 This architecture differs from the method used by `memcached`, which uses
@@ -376,7 +376,7 @@ node, Server D is added to the cluster and the vBucket Map is updated.
 ![](images/vbuckets-after.png)
 
 [The vBucket map is updated during
-therebalance](#couchbase-introduction-architecture-rebalancing) operation; the
+the rebalance](#couchbase-introduction-architecture-rebalancing) operation; the
 updated map is then sent the cluster to all the cluster participants, including
 the other nodes, any connected "smart" clients, and the Moxi proxy service.
 
@@ -488,7 +488,7 @@ Writers](#couchbase-admin-tasks-mrw).
 
 [Couchbase Server will never delete entire items from disk unless a client
 explicitly deletes the item from the database or
-theexpiration](#couchbase-introduction-architecture-expiration) value for the
+the expiration](#couchbase-introduction-architecture-expiration) value for the
 item is reached. The ejection mechanism removes an item from RAM, while keeping
 a copy of the key and metadata for that document in RAM and also keeping copy of
 that document on disk. For more information about document expiration and
@@ -666,7 +666,7 @@ provides a stream of data of the changes that are occurring within the system.
 
 TAP is used during replication, to copy data between vBuckets used for replicas.
 It is also used during the rebalance procedure to move data between vBuckets and
-redestribute the information across the system.
+redistribute the information across the system.
 
 <a id="couchbase-introduction-architecture-clientinterface"></a>
 
@@ -918,10 +918,10 @@ the basic running of a Membase cluster.
 
    To build Views that can output and query your stored data, your objects must be
    stored in the database using the JSON format. This may mean that if you have
-   been using the native serialisation of your client library to convert a language
+   been using the native serialization of your client library to convert a language
    specific object so that it can be stored into Membase Server, you will now need
    to structure your data and use a native to JSON serialization solution, or
-   reformat your data so that it can be formated as JSON.
+   reformat your data so that it can be formatted as JSON.
 
 <a id="couchbase-introduction-migration-couchdb"></a>
 

--- a/content/couchbase-manual-2.1/monitoring-couchbase.markdown
+++ b/content/couchbase-manual-2.1/monitoring-couchbase.markdown
@@ -147,7 +147,7 @@ the system is understanding how we interact with the disk subsystem.
 
 Since Couchbase Server is an asynchronous system, any mutation operation is
 committed first to DRAM and then queued to be written to disk. The client is
-returned an acknowledgement almost immediately so that it can continue working.
+returned an acknowledgment almost immediately so that it can continue working.
 There is replication involved here too, but we're ignoring it for the purposes
 of this discussion.
 
@@ -183,7 +183,7 @@ gathering node-level stats). There are two statistics to watch here:
 ep\_queue\_size (where new mutations are placed) flusher\_todo (the queue of
 items currently being written to disk)
 
-[SeeThe Dispatcher](#couchbase-monitoring-nodestats-dispatcher) for more
+[See The Dispatcher](#couchbase-monitoring-nodestats-dispatcher) for more
 information about monitoring what the disk subsystem is doing at any given time.
 
 <a id="couchbase-monitoring-stats"></a>
@@ -217,7 +217,7 @@ can be found in the repository.
 
 [Along with stats at the REST and UI level, individual nodes can also be queried
 for statistics either through a client which uses binary protocol or through
-thecbstats utility](#couchbase-admin-cmdline-cbstats) shipped with Couchbase
+the cbstats utility](#couchbase-admin-cmdline-cbstats) shipped with Couchbase
 Server.
 
 For example:

--- a/content/couchbase-manual-2.1/troubleshooting.markdown
+++ b/content/couchbase-manual-2.1/troubleshooting.markdown
@@ -15,7 +15,7 @@ more detailed investigations:
 
  * Try connecting to the Couchbase Server Web Console on the node.
 
- * [Try to use telnet to connect to the variousports](#couchbase-network-ports)
+ * [Try to use telnet to connect to the various ports](#couchbase-network-ports)
    that Couchbase Server uses.
 
  * Try reloading the web page.
@@ -97,7 +97,7 @@ platform, see [](#couchbase-troubleshooting-logs-oslocs).
 Platform | Location                                                                     
 ---------|------------------------------------------------------------------------------
 Linux    | `/opt/couchbase/var/lib/couchbase/logs`                                      
-Windows  | `C:\Program Files\Couchbase\Server\log` Assumes default installation location
+Windows  | `C:\Program Files\Couchbase\Server\log` Assumes default installation location
 Mac OS X | `~/Library/Logs`                                                             
 
 Individual log files are automatically numbered, with the number suffix
@@ -116,7 +116,7 @@ File               | Log Contents
 `info`             | Information level error messages related to the core server management subsystem, excluding information included in the `couchdb`, `xdcr` and `stats` logs.
 `error`            | Error level messages for all subsystems excluding `xdcr`.                                                                                                  
 `xcdr_error`       | XDCR error messages.                                                                                                                                       
-`xdcr`             | XSCR information messages.                                                                                                                                 
+`xdcr`             | XDCR information messages.                                                                                                                                 
 `mapreduce_errors` | JavaScript and other view-processing errors are reported in this file.                                                                                     
 `views`            | Errors relating to the integration between the view system and the core server subsystem.                                                                  
 `stats`            | Contains periodic reports of the core statistics.                                                                                                          

--- a/content/couchbase-manual-2.1/using-the-rest-api.markdown
+++ b/content/couchbase-manual-2.1/using-the-rest-api.markdown
@@ -166,7 +166,7 @@ you would use for a REST API request. This is especially for administrative
 tasks such as creating a new bucket, adding a node to a cluster, or changing
 cluster settings.
 
-[For a list of supported browsers, seeSystem
+[For a list of supported browsers, see System
 Requirements](#couchbase-getting-started-prepare). For the Couchbase Web
 Console, a separate UI hierarchy is served from each node of the system (though
 asking for the root "/" would likely return a redirect to the user agent). To
@@ -321,7 +321,7 @@ Host: 10.4.2.4:8091
 Accept: */*
 ```
 
-If Couchbase Server successfully handles the reuqest, you will get a response
+If Couchbase Server successfully handles the request, you will get a response
 similar to the following example:
 
 
@@ -1421,7 +1421,7 @@ shell> curl -v -X POST -u Administrator:Password -d name=customer \
 ```
 
 [Available parameters are identical to those available when creating a bucket.
-Seebucket parameters](#table-couchbase-admin-restapi-creating-buckets).
+See bucket parameters](#table-couchbase-admin-restapi-creating-buckets).
 
 If the request is successful, HTTP response 200 will be returned with an empty
 data content.
@@ -2591,7 +2591,7 @@ Authorization: Basic YWRtaW46YWRtaW4=
 
 200 OK
 
-Possible errrors include:
+Possible errors include:
 
 
 ```
@@ -2742,7 +2742,7 @@ many simultaneous views requests resulted in a node being overwhelmed. For
 general information about this endpoint, see [Managing Internal Cluster
 Settings](#couchbase-admin-restapi-settings-max_bucket_count).
 
- When Couchbase Server rejects an incoming connection because one of these
+When Couchbase Server rejects an incoming connection because one of these
 limits is exceeded, it responds with an HTTP status code of 503. The HTTP
 Retry-After header will be set appropriately. If the request is made to a REST
 port, the response body will provide the reason why the request was rejected. If
@@ -2762,7 +2762,7 @@ which can be made on a port. The following are all the port-related request
 parameters you can set:
 
  * **restRequestLimit** : Maximum number of simultaneous connections each node
-   should accept on a REST port. Diagnostic-related requests and 
+   should accept on a REST port. Diagnostic-related requests and 
    `/internalSettings` requests are not counted in this limit.
 
  * **capiRequestLimit** : Maximum number of simultaneous connections each node
@@ -3054,7 +3054,7 @@ shell> curl -u Administrator:password1  \
 http://10.4.2.4:8091/internalSettings
 ```
 
-You will recieve a response similar to the following. For the sake of brevity,
+You will receive a response similar to the following. For the sake of brevity,
 we are showing only the XDCR-related items:
 
 
@@ -3083,7 +3083,7 @@ The the XDCR-related values are defined as follows:
  * (Number) xdcrWorkerBatchSize: Document batching count, 500 to 10000. Default
    500.
 
- * (Number) xdcrDocBatchSizeKb: Document batching size, 10 to 100000 (kB). Default
+ * (Number) xdcrDocBatchSizeKb: Document batching size, 10 to 100000 (KB). Default
    2048.
 
  * (Number) xdcrFailureRestartInterval: Interval for restarting failed XDCR, 1 to
@@ -3170,7 +3170,7 @@ can adjust are defined as follows:
 
  * `xdcrDocBatchSizeKb` (Integer)
 
-   Document batching size, 10 to 100000 (kB). Default 2048. In general, increasing
+   Document batching size, 10 to 100000 (KB). Default 2048. In general, increasing
    this value by 2 or 3 times will improve XDCR transmissions rates, since larger
    batches of data will be sent in the same timed interval. For unidirectional
    replication from a source to a destination cluster, adjusting this setting by 2

--- a/content/couchbase-manual-2.1/using-the-web-console.markdown
+++ b/content/couchbase-manual-2.1/using-the-web-console.markdown
@@ -161,7 +161,7 @@ The `Servers` section indicates overall server information for the cluster:
 
 ![](images/web-console-cluster-overview-servers.png)
 
- * `Active Servers` is the number of active servers within the current clsuter
+ * `Active Servers` is the number of active servers within the current cluster
    configuration.
 
  * `Servers Failed Over` is the number of servers that have failed over due to an
@@ -170,7 +170,7 @@ The `Servers` section indicates overall server information for the cluster:
  * `Servers Down` shows the number of servers that are down and not-contactable.
 
  * `Servers Pending Rebalance` shows the number of servers that are currently
-   waiting to be rebalanced after joiining a cluster or being reactivated after
+   waiting to be rebalanced after joining a cluster or being reactivated after
    failover.
 
 <a id="couchbase-admin-web-console-server-nodes"></a>
@@ -348,7 +348,7 @@ and the cluster as a whole.
 
 The `Data Buckets` page displays a list of all the configured buckets on your
 system (of both Couchbase and memcached types). The page provides a quick
-overview of your cluser health from the perspective of the configured buckets,
+overview of your cluster health from the perspective of the configured buckets,
 rather than whole cluster or individual servers.
 
 The information is shown in the form of a table, as seen in the figure below.
@@ -602,7 +602,7 @@ all the graphs and statistics display within the web console.
 
    The `Data Buckets` selection list allows you to select which of the buckets
    configured on your cluster is to be used as the basis for the graph display. The
-   statistics shown are agregated over the whole cluster for the selected bucket.
+   statistics shown are aggregated over the whole cluster for the selected bucket.
 
  * `Server Selection`
 
@@ -630,7 +630,7 @@ all the graphs and statistics display within the web console.
  * `Individual Server Selection`
 
    Clicking the blue triangle next to any of the smaller statistics graphs enables
-   you to show the selected statistic individuall for each server within the
+   you to show the selected statistic individual for each server within the
    cluster, instead of aggregating the information for the entire cluster.
 
 <a id="couchbase-admin-web-console-data-buckets-individual"></a>
@@ -1076,7 +1076,7 @@ configuration. Possible include:
  * **Starting Up**
 
    The replication process has just started, and the clusters are determining what
-   data needs to be sent from the originatin cluster to the destination cluster.
+   data needs to be sent from the originating cluster to the destination cluster.
 
  * **Replicating**
 
@@ -1207,7 +1207,7 @@ The statistics shown are:
 
  * `sets per sec.`
 
-   Set operations per second for incoming XDRC data.
+   Set operations per second for incoming XDCR data.
 
  * `deletes per sec.`
 
@@ -1373,7 +1373,7 @@ Once you have edited your `map()` and `reduce()` functions, you must use the
 `Save` button to save the view definition.
 
 The design document will be validated before it is created or updated in the
-system. The validation checks for valid Javascript and for the use of valid
+system. The validation checks for valid JavaScript and for the use of valid
 built-in reduce functions. Any validation failure is reported as an error.
 
 You can also save the modified version of your view as a new view using the
@@ -1573,7 +1573,7 @@ Failover](#couchbase-admin-tasks-failover-automatic).
 
 ### Enabling Alerts
 
-You can enable email alerts to be raised when a signficant error occurs on your
+You can enable email alerts to be raised when a significant error occurs on your
 Couchbase Server cluster. The email alert system works by sending email directly
 to a configured SMTP server. Each alert email is send to the list of configured
 email recipients.
@@ -1670,7 +1670,7 @@ The available settings are:
 
     * `Writing data to disk for a specific bucket has failed`
 
-      The disk or device used for persisting data has failed to store persitent data
+      The disk or device used for persisting data has failed to store persistent data
       for a bucket.
 
 
@@ -1767,7 +1767,7 @@ information to the Couchbase server:
  * Basic information about the size and configuration of your Couchbase cluster.
    This information will be used to help us prioritize our development efforts.
 
-You can enable/disable software updaate notifications
+You can enable/disable software update notifications
 
 The process occurs within the browser accessing the web console, not within the
 server itself, and no further configuration or internet access is required on

--- a/content/couchbase-manual-2.1/views-and-indexes.markdown
+++ b/content/couchbase-manual-2.1/views-and-indexes.markdown
@@ -799,7 +799,7 @@ The `meta` structure contains the following fields and associated information:
  * `expiration`
 
    The expiration value for the stored object. The stored expiration time is always
-   sotred as an absolute Unix epoch time value.
+   stored as an absolute Unix epoch time value.
 
 These additional fields are only exposed when processing the documents within
 the view server. These fields are not returned when you access the object
@@ -1035,7 +1035,7 @@ two parts, a map function and a reduce function:
 The combination of the map and the reduce function produce the corresponding
 view. The two functions work together, with the map producing the initial
 material based on the content of each JSON document, and the reduce function
-summarising the information generated during the map phase. The reduction
+summarizing the information generated during the map phase. The reduction
 process is selectable at the point of accessing the view, you can choose whether
 to the reduce the content or not, and, by using an array as the key, you can
 specifying the grouping of the reduce information.
@@ -1168,8 +1168,8 @@ record in the generated view:
    The key content is used for querying by using a combination of this sorting
    process and the specification of either an explicit key or key range within the
    query specification. For example, if a view outputs the `RECIPE TITLE` field as
-   a key, you could obtain all the records matching 'Lasagne' by specifying that
-   only the keys matching 'Lasagne' are returned.
+   a key, you could obtain all the records matching 'Lasagna' by specifying that
+   only the keys matching 'Lasagna' are returned.
 
    For more information on querying and extracting information using the key value,
    see [Querying Views](#couchbase-views-writing-querying).
@@ -1232,8 +1232,8 @@ This is because the value specified by `emit()` is used as one of the input
 parameters to the reduce function. The reduce function is designed to reduce a
 group of values emitted by the corresponding `map()` function.
 
-Alternatively, reduce can be used for performing sums, for example totalling all
-the invoice values for a single client, or totalling up the preparation and
+Alternatively, reduce can be used for performing sums, for example totaling all
+the invoice values for a single client, or totaling up the preparation and
 cooking times in a recipe. Any calculation that can be performed on a group of
 the emitted data.
 
@@ -1281,7 +1281,7 @@ When using a reduce function the reduction is applied as follows:
     ```
 
    In each case the values for the common keys (John, Adam, James), have been
-   totalled, and the six input rows reduced to the 3 rows shown here.
+   totaled, and the six input rows reduced to the 3 rows shown here.
 
  * Results are grouped on the key from the call to `emit()` if grouping is selected
    during query time. As shown in the previous example, the reduction operates by
@@ -1308,7 +1308,7 @@ computed reduction value.
 `_count`](#couchbase-views-writing-reduce-count),
 `_sum`](#couchbase-views-writing-reduce-sum), and
 `_stats`](#couchbase-views-writing-reduce-stats). You can also write your
-owncustom reduction functions](#couchbase-views-writing-reduce-custom).
+own custom reduction functions](#couchbase-views-writing-reduce-custom).
 
 The reduce function also has a final additional benefit. The results of the
 computed reduction are stored in the index along with the rest of the view
@@ -1502,7 +1502,7 @@ The `reduce()` function has to work slightly differently to the `map()`
 function. In the primary form, a `reduce()` function must convert the data
 supplied to it from the corresponding `map()` function.
 
-The core structure of the reduce function execution is shown the figurebelow.
+The core structure of the reduce function execution is shown the figure below.
 
 
 ![](images/custom-reduce.png)
@@ -1630,7 +1630,7 @@ This can be explicitly written as follows:
 f(keys, values) = f(keys, [ f(keys, values) ])
 ```
 
-This can been seen graphically in the illustrationbelow, where previous
+This can been seen graphically in the illustration below, where previous
 reductions are included within the array of information are re-supplied to the
 reduce function as an element of the array of values supplied to the reduce
 function.
@@ -1859,7 +1859,7 @@ You should keep the following in mind while developing and deploying your views:
    combination of the update frequency requirements on the included views and
    grouping of the view definitions. For example, if you have a view that needs to
    be updated with a high frequency (for example, comments on a blog post), and
-   another view that needs to be updated less frequently (e.g. top blogposts),
+   another view that needs to be updated less frequently (e.g. top blog posts),
    separate the views into two design documents so that the comments view can be
    updated frequently, and independently, of the other view.
 
@@ -2206,7 +2206,7 @@ In the above example:
    The view being accessed in this case is a development view. To create a
    development view, you *must* use the `dev_` prefix to the view name.
 
-   As a `PUT` command, the URL is also significant, in that the location designes
+   As a `PUT` command, the URL is also significant, in that the location designates
    the name of the design document. In the example, the URL includes the name of
    the bucket ( `sales` ) and the name of the design document that will be created
    `dev_byfield`.
@@ -2227,7 +2227,7 @@ will contain the field `ok` and the ID of the design document created:
 ```
 
 The design document will be validated before it is created or updated in the
-system. The validation checks for valid Javascript and for the use of valid
+system. The validation checks for valid JavaScript and for the use of valid
 built-in reduce functions. Any validation failure is reported as an error.
 
 In the event of an error, the returned JSON will include the field `error` with
@@ -2436,7 +2436,7 @@ sequence and precedence of the different parameters during queries is shown in
 ![](images/views-query-flow.png)
 
 The core arguments and selection systems are the same through both the REST API
-interface, and the client libraries. The setting of these values differes
+interface, and the client libraries. The setting of these values differs
 between different client libraries, but the argument names and expected and
 supported values are the same across all environments.
 
@@ -2768,7 +2768,7 @@ records, including "aa":
 ```
 
 Specifying a partial string to `startkey` will trigger output of the selected
-values as soon as the first value or value greather than the specified value is
+values as soon as the first value or value greater than the specified value is
 identified. For strings, this partial match (from left to right) is identified.
 For example, specifying a `startkey` of "d" will return:
 
@@ -2789,7 +2789,7 @@ used. For example, searching a database of ingredients and specifying a
 To match all of the records for a given word or value across the entire range,
 you can use the null value in the `endkey` parameter. For example, to search for
 all records that start only with the word "almond", you specify a `startkey` of
-"almond", and an endkey of "almond\u02ad" (i.e. with the last latin character at
+"almond", and an endkey of "almond\u02ad" (i.e. with the last Latin character at
 the end). If you are using Unicode strings, you may want to use "\uefff".
 
 
@@ -3232,7 +3232,7 @@ responses during a view query.
     }
     ```
 
-   You can alter this behaviour by using the `on_error` argument. The default value
+   You can alter this behavior by using the `on_error` argument. The default value
    is `continue`. If you set this value to `stop` then the view response will cease
    the moment an error occurs. The returned JSON will contain the error information
    for the node that returned the first error. For example:
@@ -3460,7 +3460,7 @@ be created and then used to find recipes by ingredient.
 
 ```
 {
-    "title": "Fried chilli potatoes",
+    "title": "Fried chili potatoes",
     "preptime": "5"
     "servings": "4",
     "totaltime": "10",
@@ -3468,8 +3468,8 @@ be created and then used to find recipes by ingredient.
     "cooktime": "5",
     "ingredients": [
         {
-            "ingredtext": "chilli powder",
-            "ingredient": "chilli powder",
+            "ingredtext": "chili powder",
+            "ingredient": "chili powder",
             "meastext": "3-6 tsp"
         },
         {
@@ -3511,11 +3511,11 @@ To query for a specific ingredient, specify the ingredient as a key:
 
 The `keys` parameter can also be used in this situation to look for recipes that
 contain multiple ingredients. For example, to look for recipes that contain
-either "potatoes" or "chilli powder" you would use:
+either "potatoes" or "chili powder" you would use:
 
 
 ```
-?keys=["potatoes","chilli powder"]
+?keys=["potatoes","chili powder"]
 ```
 
 This will produce a list of any document containing either ingredient. A simple
@@ -3668,7 +3668,7 @@ function(doc, meta) {
 ```
 
 For convenience, you may wish to use the `dateToArray()` function, which
-convertes a date object or string into an array. For example, if the date has
+converts a date object or string into an array. For example, if the date has
 been stored within the document as a single field:
 
 
@@ -4834,7 +4834,7 @@ request. The full list is provided in the following summary table.
                             | `ok` : Allow stale views                                            
                             | `update_after` : Allow stale view, update view after access         
 
-Bounding Box QueriesIf you do not supply a bounding box, the full dataset is
+Bounding Box Queries: If you do not supply a bounding box, the full dataset is
 returned. When querying a spatial index you can use the bounding box to specify
 the boundaries of the query lookup on a given value. The specification should be
 in the form of a comma-separated list of the coordinates to use during the


### PR DESCRIPTION
Minor edits for typos, acronym fixup, removing "smart quotes", inserting a space here and there, plus removing other various and sundry unicode critters which didn't belong. Basically the same treatment as yesterday for the 2.2 Couchbase Server Manual, but applied to the 2.1 version this time.
