### PR TITLE
remove enable-index-replica from bucket edit example

### DIFF
--- a/content/couchbase-manual-2.2/command-line-interface-for-administration.markdown
+++ b/content/couchbase-manual-2.2/command-line-interface-for-administration.markdown
@@ -357,8 +357,7 @@ Set data path for an unprovisioned cluster:
        --bucket=test_bucket \
        --bucket-port=11222 \
        --bucket-ramsize=400 \
-       --enable-flush=1 \
-       --enable-index-replica=1
+       --enable-flush=1
 
   Delete a bucket:
     couchbase-cli bucket-delete -c 192.168.0.1:8091 \


### PR DESCRIPTION
Removed `--enable-index-replica` option from `couchbase-cli` `bucket-edit` subcommand for version 2.2 per [MB-8541](http://www.couchbase.com/issues/browse/MB-8541)
