### PR TITLE
fixed Hello Couchbase examples

### DIFF
--- a/content/couchbase-sdk-node-1.0/getting-started.markdown
+++ b/content/couchbase-sdk-node-1.0/getting-started.markdown
@@ -39,8 +39,8 @@ with the default install.
 var couchbase = require("couchbase");
 
 var bucket = new couchbase.Connection({
-  ‘bucket’:’beer-sample’,
-  ‘host’:’127.0.0.1:8091’
+  'bucket':'beer-sample',
+  'host':'127.0.0.1:8091'
 }, function(err) {
   if (err) {
     // Failed to make a connection to the Couchbase cluster.
@@ -55,7 +55,7 @@ var bucket = new couchbase.Connection({
 
     var doc = result.value;
 
-    console.log(doc.name + ‘, ABV: ‘ + doc.abv);
+    console.log(doc.name + ', ABV: ' + doc.abv);
 
     doc.comment = "Random beer from Norway";
 
@@ -69,7 +69,7 @@ var bucket = new couchbase.Connection({
 
       // Success!
       process.exit(0);
-    }
+    });
   });
 });
 ```

--- a/content/couchbase-sdk-node-1.1/getting-started.markdown
+++ b/content/couchbase-sdk-node-1.1/getting-started.markdown
@@ -38,8 +38,8 @@ with the default install.
 var couchbase = require("couchbase");
 
 var bucket = new couchbase.Connection({
-  ‘bucket’:’beer-sample’,
-  ‘host’:’127.0.0.1:8091’
+  'bucket':'beer-sample',
+  'host':'127.0.0.1:8091'
 }, function(err) {
   if (err) {
     // Failed to make a connection to the Couchbase cluster.
@@ -54,7 +54,7 @@ var bucket = new couchbase.Connection({
 
     var doc = result.value;
 
-    console.log(doc.name + ‘, ABV: ‘ + doc.abv);
+    console.log(doc.name + ', ABV: ' + doc.abv);
 
     doc.comment = "Random beer from Norway";
 
@@ -68,7 +68,7 @@ var bucket = new couchbase.Connection({
 
       // Success!
       process.exit(0);
-    }
+    });
   });
 });
 ```


### PR DESCRIPTION
Cleaned up the smart quotes and completed the call to `bucket.replace` to make the Hello Couchbase example work. It now throws "Error: No such key" since the _aass_brewery_juleol_ beer does not exist in default beer-sample data. 

I am curious though, should the example be updated to work against a beer that is included in the default beer-sample data?
