### PR TITLE
use guard-nanoc since nanoc watch is deprecated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,8 @@ gem 'nokogiri'
 # Webserver for 'nanoc view' command
 gem 'adsf'
 
-# Dependencies for 'nanoc watch' command
-gem 'listen'
+# File watcher configuration for guard
+gem 'guard-nanoc'
 gem 'rb-fsevent'
 gem 'rb-inotify'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       rack (>= 1.0.0)
     celluloid (0.15.2)
       timers (~> 1.1.0)
+    coderay (1.1.0)
     colored (1.2)
     commonjs (0.2.7)
     cri (2.4.0)
@@ -14,6 +15,16 @@ GEM
     foreman (0.63.0)
       dotenv (>= 0.7)
       thor (>= 0.13.6)
+    formatador (0.2.4)
+    guard (2.3.0)
+      formatador (>= 0.2.4)
+      listen (~> 2.1)
+      lumberjack (~> 1.0)
+      pry (>= 0.9.12)
+      thor (>= 0.18.1)
+    guard-nanoc (1.0.2)
+      guard (>= 1.8.0)
+      nanoc (>= 3.6.3)
     haml (4.0.4)
       tilt
     image_size (1.1.4)
@@ -24,18 +35,25 @@ GEM
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
+    lumberjack (1.0.4)
+    method_source (0.8.2)
     mime-types (2.0)
     mini_portile (0.5.2)
     nanoc (3.6.6)
       cri (~> 2.3)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
+    pry (0.9.12.4)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
     rack (1.5.2)
     rb-fsevent (0.9.3)
     rb-inotify (0.9.2)
       ffi (>= 0.5.0)
     rdiscount (2.1.7)
     ref (1.0.5)
+    slop (3.4.7)
     therubyracer (0.12.0)
       libv8 (~> 3.16.14.0)
       ref
@@ -50,10 +68,10 @@ PLATFORMS
 DEPENDENCIES
   adsf
   foreman
+  guard-nanoc
   haml
   image_size
   less
-  listen
   mime-types
   nanoc
   nokogiri

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,8 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+guard 'nanoc' do
+  watch('nanoc.yaml') # Change this to config.yaml if you use the old config file name
+  watch('Rules')
+  watch(%r{^(content|layouts|lib)/.*$})
+end

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-watcher: bundle exec nanoc watch
+watcher: bundle exec guard
 web: bundle exec nanoc view


### PR DESCRIPTION
There is an error when running nanoc watch, which is explained in 
https://github.com/nanoc/nanoc/issues/358 but since nanoc watch is deprecated
it probably makes sense to switch to guard-nanoc for file watching.
