### PR TITLE
Updates to 1.3.3 release notes Addenum

### DIFF
--- a/content/couchbase-sdk-net-1.3/appendix-release-notes.markdown
+++ b/content/couchbase-sdk-net-1.3/appendix-release-notes.markdown
@@ -6,14 +6,16 @@ Client Library .NET Issues Tracker](http://www.couchbase.com/issues/browse/NCBC)
 
 ## Release Notes for Couchbase Client Library .NET 1.3.3 GA (4 February 2014)
 
+	**Note: Version 1.3.2 was shipped as 1.3.3**
+
 <a id="couchbase-sdk-net-rn_1-3-3"></a>
 
-* <a href="http://www.couchbase.com/issues/browse/NCBC-381">Ensure that Nuget installs Newtonsoft.NET 4.5.11</a>
+* <a href="http://www.couchbase.com/issues/browse/NCBC-381">Ensure that Nuget installs Newtonsoft.NET <=5.0.8</a>
 
     If this is not specified in the .nuspec file, Nuget will attempt to
     install the lastest version 6.0.0 which is not compatible with view
-    calls using 1.3.2 version of the Couchbase .NET SDK. These incompatible
-    issues will be resolved in a future release, likely 1.3.3.
+    calls using ~~1.3.2~~ 1.3.3 version of the Couchbase .NET SDK. These incompatible
+    issues will be resolved in a future release, likely ~~1.3.3~~ 1.3.4.
 
 * <a href="http://www.couchbase.com/issues/browse/NCBC-380">NCBC-380: Filtering on Compound Key with '+' Char Fails</a>
  


### PR DESCRIPTION
Amy, made some updates to the release notes reflecting that 1.3.2 was skipped in favor of 1.3.3.

Thanks,

Jeff
