### PR TITLE
CCCP: Clarify that CCCP requires an updated client library, and the old port 8091 mechanism is still available.

### DIFF
--- a/content/couchbase-manual-2.5/cb-release-notes/cb-rn-2_5.markdown
+++ b/content/couchbase-manual-2.5/cb-release-notes/cb-rn-2_5.markdown
@@ -62,11 +62,12 @@ and [Managing XDCR data encryption CLI](../cb-cli/#cb-cli-xdcr-data-encrypt).
 
 In releases prior to Couchbase Server 2.5, a developer, via a client library of their choice, randomly selects a host from which to request an initial topology configuration. Any future changes to the cluster map following the initial bootstrap are based on the NOT_MY_VBUCKET response from the server. This connection is made to port 8091 and is based on an HTTP connection. 
 
-Starting with Couchbase Server 2.5, client libraries query a cluster for initial topology configuration for a bucket from one of the nodes in the cluster. This is similar to prior releases. However, this information is transmitted via the memcached protocol on port 11210 (rather than via persistent HTTP connections to port 8091). This significantly improves connection scaling capabilities.
+Starting with Couchbase Server 2.5, client libraries may instead query a cluster for initial topology configuration for a bucket from one of the nodes in the cluster. This is similar to prior releases. However, this information is transmitted via the memcached protocol on port 11210 (rather than via persistent HTTP connections to port 8091). This significantly improves connection scaling capabilities. 
 
 <div class="notebox"><p>Note</p>
-<p>This change is only applicable to Couchbase type buckets (not memcached buckets). An error is returned if a configuration request is received on port 8091.
-</p></div> 
+<p>This change is only applicable to Couchbase type buckets (not memcached buckets). An error is returned if a configuration request is received on port 8091.</p>
+<p>An updated client library is required take advantage of optimized connection management. Old client libraries will continue to use the port 8091 HTTP connection. See the your selected client library release notes for details.</p>
+</div>
 
 For more information, see [Using a smart (vBucket aware) client](../cb-admin/#couchbase-deployment-vbucket-client) in Deployment strategies.
 


### PR DESCRIPTION
Make this clearer to users - at least two different users have been caught out on this thinking they must change to 11210 with the current (pre-CCCP) client libraries.
