### PR TITLE
Removed reference cbbackup-incremental and cbbackup-merge-incremental. T...

### DIFF
--- a/content/couchbase-manual-2.5/cb-cli/cli-overview.markdown
+++ b/content/couchbase-manual-2.5/cb-cli/cli-overview.markdown
@@ -72,8 +72,8 @@ Tool                         | Server Versions | Description/Status
 `mbadm-online-restore`       | 1.7             | Deprecated in 1.8, replaced by `cbadm-online-restore`         
 `mbadm-online-update`        | 1.7             | Deprecated in 1.8, replaced by `cbadm-online-update`          
 `mbadm-tap-registration`     | 1.7             | Deprecated in 1.8, replaced by `cbadm-tap-registration`       
-`mbbackup-incremental`       | 1.7             | Deprecated in 1.8, replaced by `cbbackup-incremental`         
-`mbbackup-merge-incremental` | 1.7             | Deprecated in 1.8, replaced by `cbbackup-merge-incremental`   
+`mbbackup-incremental`       | 1.7             | Deprecated in 1.8       
+`mbbackup-merge-incremental` | 1.7             | Deprecated in 1.8
 `mbbackup`                   | 1.7             | Deprecated in 1.8, replaced by `cbbackup`                     
 `mbbrowse_logs`              | 1.7             | Deprecated in 1.8, replaced by `cbbrowse_logs`                
 `mbcollect_info`             | 1.7             | Deprecated in 1.8, replaced by `cbcollect_info`               


### PR DESCRIPTION
The cli tools overview mentioned cbbackup-incremental and cbbackup-merge-incremental.

Incremental back-ups are targeted to 3.0 but these tools are not in 2.5.
